### PR TITLE
Adapt MindSpeed and Megatron for version compatibility with 0.12.0

### DIFF
--- a/cookbook/megatron/lora.py
+++ b/cookbook/megatron/lora.py
@@ -151,7 +151,8 @@ def train():
 
     for step, batch in enumerate(dataloader):
         output = model.forward_backward(inputs=batch,
-                                        adapter_name=adapter_name)
+                                        adapter_name=adapter_name,
+                                        micro_batch_size=micro_batch_size)
         if step % GAS == 0:
             loss_value = output() if callable(output) else output
             logger.info(f'Step {step // GAS}, loss: {loss_value}')

--- a/cookbook/sft/lora_npu.py
+++ b/cookbook/sft/lora_npu.py
@@ -48,7 +48,7 @@ twinkle.initialize(
 
 def create_dataset():
     dataset = Dataset(dataset_meta=DatasetMeta('ms://modelscope/competition_math'))
-    dataset.set_template('Qwen3Template', model_id=MODEL_PATH)
+    dataset.set_template('Template', model_id=MODEL_PATH)
     dataset.map('CompetitionMathProcessor')
     dataset.encode(batched=True)
     return dataset
@@ -66,7 +66,7 @@ def train():
     )
 
     model.add_adapter_to_model('default', lora_config, gradient_accumulation_steps=16)
-    model.set_template('Qwen3Template')
+    model.set_template('Template')
     model.set_processor(InputProcessor, padding_side='right')
     model.set_loss(CrossEntropyLoss)
     model.set_optimizer(AdamW, lr=1e-4)

--- a/src/twinkle/model/megatron/__init__.py
+++ b/src/twinkle/model/megatron/__init__.py
@@ -5,6 +5,11 @@
 # submodules import this file first, which would crash even if the user only wants the transformers backend.
 # Follow the same LazyModule approach as `twinkle.model`: only import when those symbols are actually accessed.
 from typing import TYPE_CHECKING
+from transformers.utils import is_torch_npu_available
+
+if is_torch_npu_available():
+    # Enable Megatron on Ascend NPU
+    import mindspeed.megatron_adaptor  # F401
 
 from twinkle.utils.import_utils import _LazyModule
 


### PR DESCRIPTION
+ Adapt MindSpeed to run Megatron on NPUs.
+ The current version requirement is megatron-core>=0.12.0; remove incompatible APIs that only take effect in higher versions.
