### PR TITLE
Fix tinker loss device mismatch

### DIFF
--- a/src/twinkle/server/tinker/common/compat_base.py
+++ b/src/twinkle/server/tinker/common/compat_base.py
@@ -142,6 +142,7 @@ class TwinkleCompatModelBase:
                 token_log_probs = logps[idx, :seq_len]
 
             # elementwise_loss: positive NLL loss (0.0 where masked)
+            token_log_probs = token_log_probs.to(weights.device)
             elementwise_loss = -token_log_probs * weights
 
             results.append({


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

This PR fixes a device mismatch issue in the Tinker compatibility path during `forward_backward`.

Previously, in `src/twinkle/server/tinker/common/compat_base.py`, `_get_forward_output()` could mix tensors from different devices when computing:

```python
elementwise_loss = -token_log_probs * weights
```
In the Tinker path, logps may be materialized on CPU for transport, while weights and related tensors are placed on the accelerator device. This could trigger errors like:
<img width="1020" height="54" alt="image" src="https://github.com/user-attachments/assets/8740966f-f36a-4df4-9ca3-932cb6dec801" />

Fix:
- Align tensors based on the actual device used for loss computation.
- Ensure token_log_probs and weights are on the same device before computing elementwise_loss.