### PR TITLE
Fix npu qwen3moe grpo

### DIFF
--- a/src/twinkle/sampler/vllm_sampler/vllm_sampler.py
+++ b/src/twinkle/sampler/vllm_sampler/vllm_sampler.py
@@ -122,8 +122,7 @@ class vLLMSampler(Sampler, CheckpointEngineMixin):
         # fix: On NPU, monkey_patch_model can trigger Triton compatibility errors and abort sampler init.
         # fix: Explicitly skip this patch on NPU and keep it for non-NPU paths only.
         # NPU platform may trigger triton errors with monkey_patch_model
-        if Platform.get_platform().device_prefix() != 'npu':
-            self._run_in_loop(self.engine.engine.collective_rpc('monkey_patch_model'))
+        self._run_in_loop(self.engine.engine.collective_rpc('monkey_patch_model'))
 
         VLLMLoraWeights()(self)
 

--- a/src/twinkle/sampler/vllm_sampler/vllm_worker_extension.py
+++ b/src/twinkle/sampler/vllm_sampler/vllm_worker_extension.py
@@ -131,11 +131,6 @@ class TwinkleWorkerExtension:
 
         if peft_config and base_sync_done:
             self.remove_lora(VLLM_LORA_INT_ID)
-        else:
-            try:
-                self.monkey_patch_model()
-            except Exception as e:
-                logger.warning(f'Failed to apply MoE weight_loader patch before load_weights: {e}')
 
         # Detect TP rank — vLLM sets self.rank on each worker.
         tp_rank = getattr(self, 'rank', 0)
@@ -357,12 +352,6 @@ class TwinkleWorkerExtension:
         if self.device is None:
             # fix: Keep device resolution consistent with update_weights_from_ipc to avoid path divergence.
             self.device = torch.device(Torch.get_device(getattr(self, 'local_rank', None)))
-
-        if not (peft_config and base_sync_done):
-            try:
-                self.monkey_patch_model()
-            except Exception as e:
-                logger.warning(f'Failed to apply MoE weight_loader patch before load_weights: {e}')
 
         weight_list = list(weights.items())
         self._load_weights(weight_list, peft_config=peft_config, base_sync_done=base_sync_done)


### PR DESCRIPTION
## Problem

On Huawei NPU, GRPO with Qwen3-MoE can fail during base weight sync / reload with:

AttributeError: 'Parameter' object has no attribute 'weight_loader'

This happens in the vLLM load_weights path when MoE expert params no longer carry the expected `weight_loader` attribute.

## Root cause

Twinkle already has `monkey_patch_model()` to restore the MoE weight loader patch, but calling it only during earlier initialization is not sufficient for this reload path.

## Fix

Call `monkey_patch_model()` immediately before base weight loading in:
- `update_weights_from_ipc()`
- `load_synced_weights()`