### PR TITLE
[Fix] Add apply_patch method to vLLMSampler class in client

### DIFF
--- a/src/twinkle_client/sampler/vllm_sampler.py
+++ b/src/twinkle_client/sampler/vllm_sampler.py
@@ -8,13 +8,13 @@
 #   1. Modify the source files in src/twinkle/
 #   2. Run: python client_tools/client_generator.py
 # ============================================================================
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, Type
 from twinkle_client.http import http_post
 from twinkle.sampler.base import Sampler
 from twinkle_client.types.sampler import AddAdapterResponse, SampleResponseModel, SetTemplateResponse
 from peft import PeftConfig
 from twinkle.data_format import Trajectory, InputFeature
-
+from twinkle.patch import Patch, apply_patch
 
 class vLLMSampler(Sampler):
     """Client wrapper for Sampler that calls server HTTP endpoints.
@@ -94,3 +94,6 @@ class vLLMSampler(Sampler):
         )
         response.raise_for_status()
         return SetTemplateResponse(**response.json())
+
+    def apply_patch(self, patch_cls: Union[Patch, Type[Patch], str], **kwargs) -> None:
+        apply_patch(self, patch_cls, **kwargs)


### PR DESCRIPTION
When I run `python cookbook/client/twinkle/self_host/sample.py`, I get an error. Traceback (most recent call last):
  File "/Users/dubingnan/workCode/twinkle/cookbook/client/twinkle/self_host/sample.py", line 95, in <module>
    sample()
  File "/Users/dubingnan/workCode/twinkle/cookbook/client/twinkle/self_host/sample.py", line 41, in sample
    sampler = vLLMSampler(model_id=MODEL_ID)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Can't instantiate abstract class vLLMSampler with abstract method apply_patch

# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Write the detail information belongs to this PR.

## Experiment results

Paste your experiment result here(if needed).
