### PR TITLE
[Fix] Prevent client from importing ray via `twinkle.server.common.serialize`

### DIFF
--- a/src/twinkle_client/common/serialize.py
+++ b/src/twinkle_client/common/serialize.py
@@ -1,0 +1,43 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+import json
+from numbers import Number
+from peft import LoraConfig
+from typing import Mapping
+
+from twinkle.dataset import DatasetMeta
+
+primitive_types = (str, Number, bool, bytes, type(None))
+container_types = (Mapping, list, tuple, set, frozenset)
+basic_types = (*primitive_types, *container_types)
+
+
+def _serialize_data_slice(data_slice):
+    if data_slice is None:
+        return None
+    if isinstance(data_slice, range):
+        return {'_slice_type_': 'range', 'start': data_slice.start, 'stop': data_slice.stop, 'step': data_slice.step}
+    if isinstance(data_slice, (list, tuple)):
+        return {'_slice_type_': 'list', 'values': list(data_slice)}
+    raise ValueError(f'Http mode does not support data_slice of type {type(data_slice).__name__}. '
+                     'Supported types: range, list, tuple.')
+
+def serialize_object(obj) -> str:
+    if isinstance(obj, DatasetMeta):
+        data = obj.__dict__.copy()
+        data['data_slice'] = _serialize_data_slice(data.get('data_slice'))
+        data['_TWINKLE_TYPE_'] = 'DatasetMeta'
+        return json.dumps(data, ensure_ascii=False)
+    elif isinstance(obj, LoraConfig):
+        filtered_dict = {
+            _subkey: _subvalue
+            for _subkey, _subvalue in obj.__dict__.items()
+            if isinstance(_subvalue, basic_types) and not _subkey.startswith('_')
+        }
+        filtered_dict['_TWINKLE_TYPE_'] = 'LoraConfig'
+        return json.dumps(filtered_dict, ensure_ascii=False)
+    elif isinstance(obj, Mapping):
+        return json.dumps(obj, ensure_ascii=False)
+    elif isinstance(obj, basic_types):
+        return obj
+    else:
+        raise ValueError(f'Unsupported object: {obj}')

--- a/src/twinkle_client/http/http_utils.py
+++ b/src/twinkle_client/http/http_utils.py
@@ -45,7 +45,7 @@ def _serialize_params(params: Dict[str, Any]) -> Dict[str, Any]:
         if hasattr(value, 'processor_id'):
             serialized[key] = value.processor_id
         elif hasattr(value, '__dict__'):
-            from twinkle.server.common.serialize import serialize_object
+            from twinkle_client.common.serialize import serialize_object
             serialized[key] = serialize_object(value)
         else:
             serialized[key] = value


### PR DESCRIPTION
When I run python cookbook/client/twinkle/self_host/grpo.py, I get an error. 
```
Traceback (most recent call last):
  File "/Users/dubingnan/workCode/twinkle/cookbook/client/twinkle/self_host/grpo.py", line 295, in <module>
    train()
  File "/Users/dubingnan/workCode/twinkle/cookbook/client/twinkle/self_host/grpo.py", line 120, in train
    dataset = create_gsm8k_dataset()
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dubingnan/workCode/twinkle/cookbook/client/twinkle/self_host/grpo.py", line 94, in create_gsm8k_dataset
    dataset = Dataset(DatasetMeta('/data/dubingnan/dbn-ceph/datasets/data/gsm8k/train.jsonl', subset_name='default', split='train'))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dubingnan/workCode/twinkle/src/twinkle_client/dataset/base.py", line 27, in __init__
    response = http_post(
               ^^^^^^^^^^
  File "/Users/dubingnan/workCode/twinkle/src/twinkle_client/http/http_utils.py", line 147, in http_post
    serialized_json = _serialize_params(json_data)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dubingnan/workCode/twinkle/src/twinkle_client/http/http_utils.py", line 48, in _serialize_params
    from twinkle.server.common.serialize import serialize_object
  File "/Users/dubingnan/workCode/twinkle/src/twinkle/server/common/__init__.py", line 4, in <module>
    from .router import StickyLoraRequestRouter
  File "/Users/dubingnan/workCode/twinkle/src/twinkle/server/common/router.py", line 3, in <module>
    from ray.serve.request_router import (FIFOMixin, MultiplexMixin, PendingRequest, ReplicaID, ReplicaResult,
ModuleNotFoundError: No module named 'ray'
```

When client code (e.g., grpo.py ) calls Dataset() to create a dataset, it eventually invokes _serialize_params() in http_utils.py to serialize parameters. When this function encounters an object with __dict__ (such as DatasetMeta ), it executes:
`from twinkle.server.common.serialize import serialize_object`
However, Python executes twinkle.server.common.__init__.py first when importing twinkle.server.common.serialize . This __init__.py imports StickyLoraRequestRouter (from router.py ), which further imports ray.serve . As a result, even though the client code doesn't need ray at all, the import chain causes ModuleNotFoundError: No module named 'ray' .

# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Create a standalone serialize.py module under twinkle_client/common/ so that the client uses its own serialization logic without depending on the server package structure. 

## Experiment results

Paste your experiment result here(if needed).
