### PR TITLE
Modify remote_function decorators in multi_lora_transformers

### DIFF
--- a/src/twinkle/model/transformers/multi_lora_transformers.py
+++ b/src/twinkle/model/transformers/multi_lora_transformers.py
@@ -136,7 +136,7 @@ class MultiLoraTransformersModel(TransformersModel, PreTrainedModel):
         with self.multi_adapter.adapter(adapter_name, disable_lora=disable_lora):
             return super().forward_only(inputs=inputs, **kwargs)
 
-    @remote_function()
+    @remote_function(collect='mean')
     def calculate_loss(self, **kwargs):
         self._check_adapter_valid(kwargs.get('adapter_name'))
         with self.multi_adapter.adapter(kwargs.get('adapter_name')):
@@ -223,7 +223,7 @@ class MultiLoraTransformersModel(TransformersModel, PreTrainedModel):
         self._check_adapter_valid(kwargs.get('adapter_name'))
         super().set_processor(processor_cls, **kwargs)
 
-    @remote_function()
+    @remote_function(collect='first')
     def get_state_dict(self, **kwargs):
         self._check_adapter_valid(kwargs.get('adapter_name'))
         return self.multi_adapter.get_state_dict(kwargs.get('adapter_name'))


### PR DESCRIPTION
Updated remote_function decorators to specify collection methods.

# PR type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

When I'm using the self-host mode for LoRA SFT training, during the eval phase,
```
    for batch in dataloader:
        model.forward_only(inputs=batch)
        model.calculate_loss()
```

 the following error occurs when executing the code below:
```
Traceback (most recent call last):
  File "/data/dubingnan/dbn-ceph/exp/coder/taas/sft_rslora_lf_aligned_lr.py", line 457, in <module>
    train()
  File "/data/dubingnan/dbn-ceph/exp/coder/taas/sft_rslora_lf_aligned_lr.py", line 437, in train
    eval_metrics = evaluate(model, eval_dataloader, global_step)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/dubingnan/dbn-ceph/exp/coder/taas/sft_rslora_lf_aligned_lr.py", line 329, in evaluate
    model.calculate_loss()
  File "/data/dubingnan/dbn-ceph/twinkle/src/twinkle_client/model/multi_lora_transformers.py", line 76, in calculate_loss
    response = http_post(
               ^^^^^^^^^^
  File "/data/dubingnan/dbn-ceph/twinkle/src/twinkle_client/http/http_utils.py", line 157, in http_post
    return _handle_response(response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/dubingnan/dbn-ceph/twinkle/src/twinkle_client/http/http_utils.py", line 85, in _handle_response
    raise requests.HTTPError(http_error_msg, response=response)
requests.exceptions.HTTPError: 500 Error for url: http://10.178.165.81:8000/api/v1/model/Qwen/Qwen2.5-Coder-7B-Instruct/twinkle/calculate_loss
Server detail:
Internal Server Error
```
I found that the `calculate_loss` method in `MultiLoraTransformersModel` alters the base class's distributed semantics, causing incorrect calculations under multi-GPU DP distributed training.

Paste your experiment result here(if needed).
