### PR TITLE
reset cache for mm models

### DIFF
--- a/cookbook/rl/gkd_on_policy.py
+++ b/cookbook/rl/gkd_on_policy.py
@@ -222,6 +222,8 @@ def main():
     )
     student_sampler.set_template('Qwen3_5Template', model_id=STUDENT_MODEL_ID, enable_thinking=False)
 
+    student_sampler.reset_mm_cache()
+
     # ── Teacher vLLM sampler (for prompt logprobs) ───────────────────────────────
     teacher_sampler = vLLMSampler(
         model_id=TEACHER_MODEL_ID,
@@ -236,6 +238,7 @@ def main():
         remote_group='teacher_sampler',
     )
     teacher_sampler.set_template('Qwen3_5Template', model_id=TEACHER_MODEL_ID, enable_thinking=False)
+    teacher_sampler.reset_mm_cache()
 
     # ── DataLoader (prompt-only) ───────────────────────────────────────────────
     dataloader = DataLoader(
@@ -264,6 +267,7 @@ def main():
         # lora will be merged into the base model and sync all weights to vLLM
         ckpt_manager.sync_weights(merge_and_sync=False)
         student_sampler.reset_prefix_cache()
+        student_sampler.reset_encoder_cache()
 
         # 2. Student vLLM generates completions
         sample_response = student_sampler.sample(batch, SamplingParams(max_tokens=MAX_NEW_TOKENS, temperature=1.0, num_samples=N_SAMPLES))

--- a/cookbook/rl/grpo_mm.py
+++ b/cookbook/rl/grpo_mm.py
@@ -187,7 +187,7 @@ def main():
         remote_group='sampler',
     )
     sampler.set_template('Qwen3_5Template', model_id=MODEL_ID, enable_thinking=False)
-
+    sampler.reset_mm_cache()
     # Checkpoint manager
     ckpt_manager = CheckpointEngineManager(model=model, sampler=sampler)
 
@@ -222,7 +222,7 @@ def main():
         # lora will be merged into the base model and sync all weights to vLLM
         ckpt_manager.sync_weights(merge_and_sync=False)
         sampler.reset_prefix_cache()
-
+        sampler.reset_encoder_cache()
         # Expand prompts: each prompt repeated NUM_GENERATIONS times consecutively
         # so that GRPOAdvantage groups rewards correctly per prompt
         expand_prompts = []

--- a/src/twinkle/sampler/vllm_sampler/vllm_engine.py
+++ b/src/twinkle/sampler/vllm_sampler/vllm_engine.py
@@ -462,6 +462,15 @@ class VLLMEngine(BaseSamplerEngine):
     async def reset_prefix_cache(self) -> None:
         await self.engine.reset_prefix_cache()
 
+    async def reset_mm_cache(self) -> None:
+        await self.engine.reset_mm_cache()
+
+    async def reset_encoder_cache(self) -> None:
+        # introduced in vllm 0.16
+        if not hasattr(self.engine, 'reset_encoder_cache'):
+            return
+        await self.engine.reset_encoder_cache()
+
     async def get_state_keys(self) -> List[str]:
         results = await self.engine.collective_rpc('get_state_keys')
         all_keys = set()

--- a/src/twinkle/sampler/vllm_sampler/vllm_engine.py
+++ b/src/twinkle/sampler/vllm_sampler/vllm_engine.py
@@ -463,10 +463,24 @@ class VLLMEngine(BaseSamplerEngine):
         await self.engine.reset_prefix_cache()
 
     async def reset_mm_cache(self) -> None:
+        """Clear the multimodal processor cache and profiling dummy data.
+
+        Should be called once after engine initialization to free memory
+        used by dummy inputs during vLLM profiling (dummy run).  Also
+        clears the mm_processor_cache so that subsequent requests are
+        processed fresh.
+        """
         await self.engine.reset_mm_cache()
 
     async def reset_encoder_cache(self) -> None:
-        # introduced in vllm 0.16
+        """Clear the GPU-side vision encoder embedding cache.
+
+        Must be called after model weights are updated (e.g. via
+        ``receive_weights``) to ensure stale embeddings computed with
+        old weights are not reused for the same images.
+
+        Requires vLLM >= 0.16.
+        """
         if not hasattr(self.engine, 'reset_encoder_cache'):
             return
         await self.engine.reset_encoder_cache()

--- a/src/twinkle/sampler/vllm_sampler/vllm_sampler.py
+++ b/src/twinkle/sampler/vllm_sampler/vllm_sampler.py
@@ -383,6 +383,14 @@ class vLLMSampler(Sampler, CheckpointEngineMixin):
         self._run_in_loop(self.engine.reset_prefix_cache())
 
     @remote_function(dispatch='all', collect='first')
+    def reset_mm_cache(self):
+        self._run_in_loop(self.engine.reset_mm_cache())
+
+    @remote_function(dispatch='all', collect='first')
+    def reset_encoder_cache(self):
+        self._run_in_loop(self.engine.reset_encoder_cache())
+
+    @remote_function(dispatch='all', collect='first')
     def get_state_keys(self):
         return self._run_in_loop(self.engine.get_state_keys())
 


### PR DESCRIPTION
Add two vllm reset cache interfaces for multi-modal models, and update cookbooks