### PR TITLE
[Feature] get lora capacity info

### DIFF
--- a/src/twinkle/server/gateway/tinker_gateway_handlers.py
+++ b/src/twinkle/server/gateway/tinker_gateway_handlers.py
@@ -33,14 +33,6 @@ def _register_tinker_routes(app: FastAPI, self_fn: Callable[[], GatewayServer]) 
     It is wired in via ``Depends`` so it is resolved lazily at request time.
     """
 
-    @app.get('/capacity_info')
-    async def get_capacity_info(
-            request: Request,
-            self: GatewayServer = Depends(self_fn),
-    ) -> dict:
-        info = await self.state.get_capacity_info()
-        return info
-
     @app.get('/healthz')
     async def healthz(request: Request) -> types.HealthResponse:
         return types.HealthResponse(status='ok')

--- a/src/twinkle/server/gateway/tinker_gateway_handlers.py
+++ b/src/twinkle/server/gateway/tinker_gateway_handlers.py
@@ -33,6 +33,14 @@ def _register_tinker_routes(app: FastAPI, self_fn: Callable[[], GatewayServer]) 
     It is wired in via ``Depends`` so it is resolved lazily at request time.
     """
 
+    @app.get('/capacity_info')
+    async def get_capacity_info(
+            request: Request,
+            self: GatewayServer = Depends(self_fn),
+    ) -> dict:
+        info = await self.state.get_capacity_info()
+        return info
+
     @app.get('/healthz')
     async def healthz(request: Request) -> types.HealthResponse:
         return types.HealthResponse(status='ok')

--- a/src/twinkle/server/gateway/twinkle_gateway_handlers.py
+++ b/src/twinkle/server/gateway/twinkle_gateway_handlers.py
@@ -24,6 +24,14 @@ logger = get_logger()
 def _register_twinkle_routes(app: FastAPI, self_fn: Callable[[], GatewayServer]) -> None:
     """Register all /twinkle/* routes on the given FastAPI app."""
 
+    @app.get('/twinkle/capacity_info', response_model=types.CapacityInfoResponse)
+    async def get_capacity_info(
+            request: Request,
+            self: GatewayServer = Depends(self_fn),
+    ) -> types.CapacityInfoResponse:
+        info = await self.state.get_capacity_info()
+        return types.CapacityInfoResponse(**info)
+
     @app.get('/twinkle/healthz', response_model=types.HealthResponse)
     async def healthz(request: Request) -> types.HealthResponse:
         return types.HealthResponse(status='ok')

--- a/src/twinkle/server/model/app.py
+++ b/src/twinkle/server/model/app.py
@@ -163,6 +163,10 @@ def build_model_app(model_id: str,
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
+        try:
+            await get_self()._ensure_replica_registered()
+        except Exception as e:
+            logger.warning(f'Failed to register replica at startup: {e}')
         yield
         try:
             await get_self().shutdown()

--- a/src/twinkle/server/model/app.py
+++ b/src/twinkle/server/model/app.py
@@ -85,7 +85,15 @@ class ModelManagement(TaskQueueMixin, AdapterManagerMixin):
         # Initialize mixins
         self._init_task_queue(TaskQueueConfig.from_dict(queue_config), deployment_name='Model')
         self._init_adapter_manager(**(adapter_config or {}))
+        self._register_replica_at_startup()
         # Note: countdown task is started lazily in _ensure_sticky()
+
+    def _register_replica_at_startup(self) -> None:
+        try:
+            self.state.register_replica_blocking(self.replica_id, self.max_loras)
+            self._replica_registered = True
+        except Exception as e:
+            logger.warning(f'Failed to register replica at startup: {e}')
 
     async def _ensure_replica_registered(self):
         """Lazily register replica on first async request."""

--- a/src/twinkle/server/model/app.py
+++ b/src/twinkle/server/model/app.py
@@ -85,15 +85,7 @@ class ModelManagement(TaskQueueMixin, AdapterManagerMixin):
         # Initialize mixins
         self._init_task_queue(TaskQueueConfig.from_dict(queue_config), deployment_name='Model')
         self._init_adapter_manager(**(adapter_config or {}))
-        self._register_replica_at_startup()
         # Note: countdown task is started lazily in _ensure_sticky()
-
-    def _register_replica_at_startup(self) -> None:
-        try:
-            self.state.register_replica_blocking(self.replica_id, self.max_loras)
-            self._replica_registered = True
-        except Exception as e:
-            logger.warning(f'Failed to register replica at startup: {e}')
 
     async def _ensure_replica_registered(self):
         """Lazily register replica on first async request."""

--- a/src/twinkle/server/model/tinker_handlers.py
+++ b/src/twinkle/server/model/tinker_handlers.py
@@ -41,7 +41,8 @@ def _register_tinker_routes(app: FastAPI, self_fn: Callable[[], ModelManagement]
         async def _create_adapter():
             _model_id = None
             try:
-                _model_id = await self.state.register_model(body.model_dump(), token=token, replica_id=self.replica_id)
+                _model_id = await self.state.register_model(
+                    body.model_dump(), token=token, replica_id=self.replica_id, session_id=body.session_id)
                 if body.lora_config:
                     # TODO: Make LoraConfig more flexible
                     lora_cfg = LoraConfig(r=body.lora_config.rank, target_modules='all-linear')

--- a/src/twinkle/server/model/twinkle_handlers.py
+++ b/src/twinkle/server/model/twinkle_handlers.py
@@ -510,6 +510,7 @@ def _register_twinkle_routes(app: FastAPI, self_fn: Callable[[], ModelManagement
                 token=token,
                 model_id=adapter_name,
                 replica_id=self.replica_id,
+                session_id=session_id,
             )
             try:
                 self.register_resource(adapter_name, token, session_id)

--- a/src/twinkle/server/model/twinkle_handlers.py
+++ b/src/twinkle/server/model/twinkle_handlers.py
@@ -496,8 +496,6 @@ def _register_twinkle_routes(app: FastAPI, self_fn: Callable[[], ModelManagement
             config = deserialize_object(body.config)
             extra_kwargs = body.model_extra or {}
             training_run_manager = create_training_run_manager(token, client_type='twinkle')
-            self.register_resource(adapter_name, token, session_id)
-            self.model.add_adapter_to_model(adapter_name, config, **extra_kwargs)
 
             lora_config = None
             if isinstance(config, LoraConfig):
@@ -507,6 +505,19 @@ def _register_twinkle_routes(app: FastAPI, self_fn: Callable[[], ModelManagement
                 lora_config=lora_config,
                 save_dir=resolved_save_dir,
                 user_metadata={'adapter_name': body.adapter_name})
+            await self.state.register_model(
+                run_config.model_dump(),
+                token=token,
+                model_id=adapter_name,
+                replica_id=self.replica_id,
+            )
+            try:
+                self.register_resource(adapter_name, token, session_id)
+                self.model.add_adapter_to_model(adapter_name, config, **extra_kwargs)
+            except Exception:
+                self.unregister_resource(adapter_name)
+                await self.state.unload_model(adapter_name)
+                raise
             training_run_manager.save(adapter_name, run_config)
             return {'status': 'ok', 'adapter_name': adapter_name}
 

--- a/src/twinkle/server/utils/state/model_manager.py
+++ b/src/twinkle/server/utils/state/model_manager.py
@@ -28,6 +28,20 @@ class ModelManager(BaseManager[ModelRecord]):
         # replica_id -> max_loras limit declared at registration time
         self._replica_max_loras: dict[str, int] = {}
 
+    def get_capacity_info(self) -> dict[str, int]:
+        """Return global LoRA capacity across all registered replicas.
+
+        Returns:
+            Dict containing 'max_loras', 'used_loras', and 'free_loras'.
+        """
+        total_max_loras = sum(self._replica_max_loras.values())
+        total_used_loras = sum(len(self._replica_models.get(rid, set())) for rid in self._replica_max_loras.keys())
+        return {
+            'max_loras': total_max_loras,
+            'used_loras': total_used_loras,
+            'free_loras': max(0, total_max_loras - total_used_loras),
+        }
+
     # ----- Replica Registration -----
 
     def register_replica(self, replica_id: str, max_loras: int) -> None:

--- a/src/twinkle/server/utils/state/server_state.py
+++ b/src/twinkle/server/utils/state/server_state.py
@@ -102,7 +102,8 @@ class ServerState:
                              payload: dict[str, Any],
                              token: str,
                              model_id: str | None = None,
-                             replica_id: str | None = None) -> str:
+                             replica_id: str | None = None,
+                             session_id: str | None = None) -> str:
         """Register a new model with the server state.
 
         Args:
@@ -110,6 +111,8 @@ class ServerState:
             token: User token that owns this model. Required.
             model_id: Optional explicit model_id; otherwise auto-generated.
             replica_id: Optional replica that is hosting this model.
+            session_id: Optional owning session; enables cascade cleanup when
+                the session expires. Falls back to ``payload['session_id']``.
 
         Returns:
             The model_id for the registered model.
@@ -120,7 +123,7 @@ class ServerState:
         _model_id = re.sub(r'[^\w\-]', '_', _model_id)
 
         record = ModelRecord(
-            session_id=payload.get('session_id'),
+            session_id=session_id or payload.get('session_id'),
             model_seq_id=payload.get('model_seq_id'),
             base_model=payload.get('base_model'),
             user_metadata=payload.get('user_metadata') or {},
@@ -397,8 +400,9 @@ class ServerStateProxy:
                              payload: dict[str, Any],
                              token: str,
                              model_id: str | None = None,
-                             replica_id: str | None = None) -> str:
-        return await self._actor.register_model.remote(payload, token, model_id, replica_id)
+                             replica_id: str | None = None,
+                             session_id: str | None = None) -> str:
+        return await self._actor.register_model.remote(payload, token, model_id, replica_id, session_id)
 
     async def unload_model(self, model_id: str) -> bool:
         return await self._actor.unload_model.remote(model_id)
@@ -410,9 +414,6 @@ class ServerStateProxy:
 
     async def register_replica(self, replica_id: str, max_loras: int) -> None:
         await self._actor.register_replica.remote(replica_id, max_loras)
-
-    def register_replica_blocking(self, replica_id: str, max_loras: int) -> None:
-        ray.get(self._actor.register_replica.remote(replica_id, max_loras))
 
     async def unregister_replica(self, replica_id: str) -> None:
         await self._actor.unregister_replica.remote(replica_id)

--- a/src/twinkle/server/utils/state/server_state.py
+++ b/src/twinkle/server/utils/state/server_state.py
@@ -57,6 +57,9 @@ class ServerState:
         self._metrics_running = False
         self._metrics_update_interval: float = float(kwargs.get('metrics_update_interval', 15.0))
 
+    async def get_capacity_info(self) -> dict[str, int]:
+        return self._model_mgr.get_capacity_info()
+
     # ----- Session Management -----
 
     async def create_session(self, payload: dict[str, Any]) -> str:
@@ -373,6 +376,9 @@ class ServerStateProxy:
 
     def __init__(self, actor_handle) -> None:
         self._actor = actor_handle
+
+    async def get_capacity_info(self) -> dict[str, int]:
+        return await self._actor.get_capacity_info.remote()
 
     # ----- Session Management -----
 

--- a/src/twinkle/server/utils/state/server_state.py
+++ b/src/twinkle/server/utils/state/server_state.py
@@ -411,6 +411,9 @@ class ServerStateProxy:
     async def register_replica(self, replica_id: str, max_loras: int) -> None:
         await self._actor.register_replica.remote(replica_id, max_loras)
 
+    def register_replica_blocking(self, replica_id: str, max_loras: int) -> None:
+        ray.get(self._actor.register_replica.remote(replica_id, max_loras))
+
     async def unregister_replica(self, replica_id: str) -> None:
         await self._actor.unregister_replica.remote(replica_id)
 

--- a/src/twinkle_client/manager.py
+++ b/src/twinkle_client/manager.py
@@ -5,7 +5,7 @@ import atexit
 import threading
 from typing import Any, Dict, List, Optional, Tuple
 from twinkle import get_logger
-from twinkle_client.types.server import (DeleteCheckpointResponse, GetServerCapabilitiesResponse)
+from twinkle_client.types.server import (CapacityInfoResponse, DeleteCheckpointResponse, GetServerCapabilitiesResponse)
 from twinkle_client.types.session import (CreateSessionRequest, CreateSessionResponse, SessionHeartbeatRequest,
                                            SessionHeartbeatResponse)
 from twinkle_client.types.training import (Checkpoint, Cursor, ParsedCheckpointTwinklePath, TrainingRun,
@@ -76,20 +76,20 @@ class TwinkleClient:
         self._heartbeat_thread.start()
         atexit.register(self.close)
 
-    def get_capacity_info(self) -> dict:
+    def get_capacity_info(self) -> CapacityInfoResponse:
         """
         Get the server's global LoRA capacity information.
 
         Returns:
-            dict: Containing 'max_loras', 'used_loras', and 'free_loras'.
+            :class:`~twinkle_client.types.server.CapacityInfoResponse` with
+            ``max_loras``, ``used_loras``, and ``free_loras`` fields.
 
         Raises:
             TwinkleClientError: If the request fails.
         """
-        from twinkle_client.types.server import CapacityInfoResponse
         response = http_get(self._get_url('/capacity_info'))
         data = self._handle_response(response)
-        return CapacityInfoResponse(**data).model_dump()
+        return CapacityInfoResponse(**data)
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/twinkle_client/manager.py
+++ b/src/twinkle_client/manager.py
@@ -76,6 +76,21 @@ class TwinkleClient:
         self._heartbeat_thread.start()
         atexit.register(self.close)
 
+    def get_capacity_info(self) -> dict:
+        """
+        Get the server's global LoRA capacity information.
+
+        Returns:
+            dict: Containing 'max_loras', 'used_loras', and 'free_loras'.
+
+        Raises:
+            TwinkleClientError: If the request fails.
+        """
+        from twinkle_client.types.server import CapacityInfoResponse
+        response = http_get(self._get_url('/capacity_info'))
+        data = self._handle_response(response)
+        return CapacityInfoResponse(**data).model_dump()
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------

--- a/src/twinkle_client/types/__init__.py
+++ b/src/twinkle_client/types/__init__.py
@@ -76,6 +76,7 @@ from .server import (
     SupportedModel,
     WeightsInfoRequest,
     WeightsInfoResponse as ServerWeightsInfoResponse,
+    CapacityInfoResponse,
 )
 from .session import CreateSessionRequest, CreateSessionResponse, SessionHeartbeatRequest, SessionHeartbeatResponse
 from .training import (

--- a/src/twinkle_client/types/server.py
+++ b/src/twinkle_client/types/server.py
@@ -40,3 +40,10 @@ class CheckpointPathResponse(BaseModel):
     """Response body for the /checkpoint_path endpoint."""
     path: str
     twinkle_path: str
+
+
+class CapacityInfoResponse(BaseModel):
+    """Response body for the /capacity_info endpoint."""
+    max_loras: int
+    used_loras: int
+    free_loras: int


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

## Summary

Adds a `capacity_info` endpoint for querying current LoRA capacity across registered model replicas.

## API

### Tinker-Compatible Endpoint

```bash
GET /api/v1/capacity_info
```

### Twinkle Endpoint

```bash
GET /api/v1/twinkle/capacity_info
```

Response format:

```json
{
  "max_loras": 5,
  "used_loras": 0,
  "free_loras": 5
}
```

Fields:

- `max_loras`: Total LoRA capacity across registered replicas.
- `used_loras`: Number of currently loaded LoRA adapters.
- `free_loras`: Remaining available LoRA slots.


Write the detail information belongs to this PR.

