### PR TITLE
[bugfix]: Add compatibility handling for Qwen3.5 GatedDeltaNet padding-free training and fix create_causal_mask patch when cache_positions removed in transformers >5.3.0

### DIFF
--- a/src/twinkle/model/transformers/strategy/sequence_parallel/__init__.py
+++ b/src/twinkle/model/transformers/strategy/sequence_parallel/__init__.py
@@ -110,9 +110,10 @@ class SequenceParallel:
         try:
             from transformers import masking_utils
 
+            origin_sdpa = masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._global_mapping['sdpa']
+            origin_uses_cache_position = 'cache_position' in inspect.signature(origin_sdpa).parameters
+
             def sdpa_mask(batch_size, q_length=None, kv_length=None, *args, **kwargs):
-                origin_sdpa = masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._global_mapping['sdpa_origin']
-                origin_uses_cache_position = 'cache_position' in inspect.signature(origin_sdpa).parameters
                 q_length = q_length if q_length is not None else kwargs.pop('cache_position', None)
                 device = q_length.device if torch.is_tensor(q_length) else kwargs.pop('device', None)
                 if device is None:
@@ -154,8 +155,7 @@ class SequenceParallel:
 
                 return origin_sdpa(batch_size, q_length, kv_length, *args, device=device, **kwargs)
 
-            masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._global_mapping[
-                'sdpa_origin'] = masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._global_mapping['sdpa']
+            masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._global_mapping['sdpa_origin'] = origin_sdpa
             masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._global_mapping['sdpa'] = sdpa_mask
 
             def create_causal_mask(config,

--- a/src/twinkle/model/transformers/strategy/sequence_parallel/__init__.py
+++ b/src/twinkle/model/transformers/strategy/sequence_parallel/__init__.py
@@ -114,20 +114,37 @@ class SequenceParallel:
                 origin_sdpa = masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._global_mapping['sdpa_origin']
                 origin_uses_cache_position = 'cache_position' in inspect.signature(origin_sdpa).parameters
                 q_length = q_length if q_length is not None else kwargs.pop('cache_position', None)
-                device = q_length.device if torch.is_tensor(q_length) else kwargs.get('device')
+                device = q_length.device if torch.is_tensor(q_length) else kwargs.pop('device', None)
                 if device is None:
                     device = self.real_position_ids.device
 
                 cache_position = None
-                if self.world_size > 1 and origin_uses_cache_position:
+                if self.world_size > 1:
                     padded_position_ids = self.pad(
                         self.real_position_ids[0],
                         padding_value=-1,
                         position_ids=self.real_position_ids,
                         dim=0,
                     )
-                    cache_position = torch.arange(0, padded_position_ids.shape[0], device=device)
-                    kv_length = cache_position.shape[0]
+                    global_length = padded_position_ids.shape[0]
+                    if origin_uses_cache_position:
+                        cache_position = torch.arange(0, global_length, device=device)
+                        kv_length = global_length
+                    else:
+                        # Newer Transformers passes q_length/q_offset instead of cache_position. In SP training,
+                        # create_causal_mask may still see the local shard length, so restore the global query length
+                        # only for the no-cache prefill path; cache/sliding paths keep their upstream offsets.
+                        q_offset = kwargs.get('q_offset', 0)
+                        kv_offset = kwargs.get('kv_offset', 0)
+                        no_cache_offsets = ((not torch.is_tensor(q_offset) and q_offset == 0)
+                                            and (not torch.is_tensor(kv_offset) and kv_offset == 0))
+                        if no_cache_offsets:
+                            q_length = global_length
+                            attention_mask = kwargs.get('attention_mask')
+                            if attention_mask is not None and torch.is_tensor(attention_mask):
+                                kv_length = attention_mask.shape[-1]
+                            else:
+                                kv_length = global_length
 
                 if origin_uses_cache_position:
                     if cache_position is None:

--- a/src/twinkle/model/transformers/strategy/sequence_parallel/__init__.py
+++ b/src/twinkle/model/transformers/strategy/sequence_parallel/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
+import inspect
 import math
 import torch
 import torch.distributed as dist
@@ -26,6 +27,38 @@ def is_qwen3_vl(model):
 def is_qwen3_omni(model):
     mt = getattr(getattr(model, 'config', None), 'model_type', '')
     return 'qwen3_omni' in mt
+
+
+def _call_with_supported_kwargs(fn, *args, **kwargs):
+    signature = inspect.signature(fn)
+    if not any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()):
+        kwargs = {key: value for key, value in kwargs.items() if key in signature.parameters}
+    return fn(*args, **kwargs)
+
+
+def _call_create_causal_mask(fn, config, input_embeds, attention_mask, cache_position_or_past_key_values, *args,
+                             **kwargs):
+    if 'cache_position' in inspect.signature(fn).parameters:
+        return _call_with_supported_kwargs(
+            fn,
+            config,
+            input_embeds,
+            attention_mask,
+            cache_position_or_past_key_values,
+            *args,
+            **kwargs,
+        )
+    if cache_position_or_past_key_values is None and 'past_key_values' in kwargs:
+        return _call_with_supported_kwargs(fn, config, input_embeds, attention_mask, *args, **kwargs)
+    return _call_with_supported_kwargs(
+        fn,
+        config,
+        input_embeds,
+        attention_mask,
+        cache_position_or_past_key_values,
+        *args,
+        **kwargs,
+    )
 
 
 # main content copied from ms-swift
@@ -77,59 +110,72 @@ class SequenceParallel:
         try:
             from transformers import masking_utils
 
-            _origin_flash_attention_mask = masking_utils.flash_attention_mask
+            def sdpa_mask(batch_size, q_length=None, kv_length=None, *args, **kwargs):
+                origin_sdpa = masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._global_mapping['sdpa_origin']
+                origin_uses_cache_position = 'cache_position' in inspect.signature(origin_sdpa).parameters
+                q_length = q_length if q_length is not None else kwargs.pop('cache_position', None)
+                device = q_length.device if torch.is_tensor(q_length) else kwargs.get('device')
+                if device is None:
+                    device = self.real_position_ids.device
 
-            # Patch attention masks for SP: avoid masking when full sequence is reconstructed.
-            def flash_attention_mask(batch_size,
-                                     cache_position,
-                                     kv_length,
-                                     kv_offset=0,
-                                     mask_function=masking_utils.causal_mask_function,
-                                     attention_mask=None,
-                                     **kwargs):
-                if self.world_size == 1:
-                    return _origin_flash_attention_mask(batch_size, cache_position, kv_length, kv_offset, mask_function,
-                                                        attention_mask, **kwargs)
-                if attention_mask is not None:
-                    if attention_mask.all():
-                        attention_mask = None
+                cache_position = None
+                if self.world_size > 1 and origin_uses_cache_position:
+                    padded_position_ids = self.pad(
+                        self.real_position_ids[0],
+                        padding_value=-1,
+                        position_ids=self.real_position_ids,
+                        dim=0,
+                    )
+                    cache_position = torch.arange(0, padded_position_ids.shape[0], device=device)
+                    kv_length = cache_position.shape[0]
 
-                return attention_mask
+                if origin_uses_cache_position:
+                    if cache_position is None:
+                        cache_position = q_length if torch.is_tensor(q_length) else torch.arange(
+                            q_length, device=device)
+                    return origin_sdpa(batch_size, cache_position, kv_length, *args, **kwargs)
 
-            masking_utils.flash_attention_mask = flash_attention_mask
-            masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._global_mapping['flash_attention_2'] = flash_attention_mask
-
-            def sdpa_mask(batch_size, cache_position, kv_length, *args, **kwargs):
-                if self.world_size == 1:
-                    return masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._global_mapping['sdpa_origin'](batch_size,
-                                                                                                     cache_position,
-                                                                                                     kv_length, *args,
-                                                                                                     **kwargs)
-                device = cache_position.device
-                cache_position = self.real_position_ids[0]
-                cache_position = self.pad(cache_position, padding_value=-1, position_ids=self.real_position_ids, dim=0)
-                cache_position = torch.arange(0, cache_position.shape[0], device=device)
-                kv_length = cache_position.shape[0]
-                return masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._global_mapping['sdpa_origin'](batch_size,
-                                                                                                 cache_position,
-                                                                                                 kv_length, *args,
-                                                                                                 **kwargs)
+                return origin_sdpa(batch_size, q_length, kv_length, *args, device=device, **kwargs)
 
             masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._global_mapping[
                 'sdpa_origin'] = masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._global_mapping['sdpa']
             masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._global_mapping['sdpa'] = sdpa_mask
 
-            def create_causal_mask(config, input_embeds, attention_mask, cache_position, *args, **kwargs):
+            def create_causal_mask(config,
+                                   input_embeds,
+                                   attention_mask,
+                                   cache_position_or_past_key_values=None,
+                                   *args,
+                                   **kwargs):
                 if self.world_size == 1:
-                    return masking_utils.origin_create_causal_mask(config, input_embeds, attention_mask, cache_position,
-                                                                   *args, **kwargs)
+                    return _call_create_causal_mask(
+                        masking_utils.origin_create_causal_mask,
+                        config,
+                        input_embeds,
+                        attention_mask,
+                        cache_position_or_past_key_values,
+                        *args,
+                        **kwargs,
+                    )
                 input_embeds = torch.ones(
                     (input_embeds.shape[0], input_embeds.shape[1] * self.sp_world_size, input_embeds.shape[2]),
                     dtype=input_embeds.dtype,
                     device=input_embeds.device)
-                cache_position = torch.arange(0, input_embeds.shape[1], device=input_embeds.device)
-                return masking_utils.origin_create_causal_mask(config, input_embeds, attention_mask, cache_position,
-                                                               *args, **kwargs)
+                if 'cache_position' in inspect.signature(masking_utils.origin_create_causal_mask).parameters:
+                    cache_position_or_past_key_values = torch.arange(
+                        0,
+                        input_embeds.shape[1],
+                        device=input_embeds.device,
+                    )
+                return _call_create_causal_mask(
+                    masking_utils.origin_create_causal_mask,
+                    config,
+                    input_embeds,
+                    attention_mask,
+                    cache_position_or_past_key_values,
+                    *args,
+                    **kwargs,
+                )
 
             masking_utils.origin_create_causal_mask = masking_utils.create_causal_mask
             masking_utils.create_causal_mask = create_causal_mask

--- a/src/twinkle/model/transformers/strategy/sequence_parallel/__init__.py
+++ b/src/twinkle/model/transformers/strategy/sequence_parallel/__init__.py
@@ -1,5 +1,4 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
-import inspect
 import math
 import torch
 import torch.distributed as dist
@@ -13,6 +12,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from twinkle.patch import apply_patch
 from twinkle.utils import DeviceMesh
 from twinkle.utils.transformers_utils import get_llm_model
+from twinkle.utils.utils import call_with_supported_kwargs, has_signature_parameter
 from .linear_attention_sp import Qwen3_5GatedDeltaNetUlyssesPatch
 from .utils import (DistributedAttention, GatherLoss, _derive_sequence_parallel_sizes, _get_seq_groups_from_device_mesh,
                     _get_ulysses_size, _SeqAllToAll, get_config_attr, get_cu_seqlens_from_position_ids, is_hccl_backend,
@@ -29,17 +29,10 @@ def is_qwen3_omni(model):
     return 'qwen3_omni' in mt
 
 
-def _call_with_supported_kwargs(fn, *args, **kwargs):
-    signature = inspect.signature(fn)
-    if not any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()):
-        kwargs = {key: value for key, value in kwargs.items() if key in signature.parameters}
-    return fn(*args, **kwargs)
-
-
 def _call_create_causal_mask(fn, config, input_embeds, attention_mask, cache_position_or_past_key_values, *args,
                              **kwargs):
-    if 'cache_position' in inspect.signature(fn).parameters:
-        return _call_with_supported_kwargs(
+    if has_signature_parameter(fn, 'cache_position'):
+        return call_with_supported_kwargs(
             fn,
             config,
             input_embeds,
@@ -49,8 +42,8 @@ def _call_create_causal_mask(fn, config, input_embeds, attention_mask, cache_pos
             **kwargs,
         )
     if cache_position_or_past_key_values is None and 'past_key_values' in kwargs:
-        return _call_with_supported_kwargs(fn, config, input_embeds, attention_mask, *args, **kwargs)
-    return _call_with_supported_kwargs(
+        return call_with_supported_kwargs(fn, config, input_embeds, attention_mask, *args, **kwargs)
+    return call_with_supported_kwargs(
         fn,
         config,
         input_embeds,
@@ -111,7 +104,7 @@ class SequenceParallel:
             from transformers import masking_utils
 
             origin_sdpa = masking_utils.ALL_MASK_ATTENTION_FUNCTIONS._global_mapping['sdpa']
-            origin_uses_cache_position = 'cache_position' in inspect.signature(origin_sdpa).parameters
+            origin_uses_cache_position = has_signature_parameter(origin_sdpa, 'cache_position')
 
             def sdpa_mask(batch_size, q_length=None, kv_length=None, *args, **kwargs):
                 q_length = q_length if q_length is not None else kwargs.pop('cache_position', None)
@@ -178,7 +171,7 @@ class SequenceParallel:
                     (input_embeds.shape[0], input_embeds.shape[1] * self.sp_world_size, input_embeds.shape[2]),
                     dtype=input_embeds.dtype,
                     device=input_embeds.device)
-                if 'cache_position' in inspect.signature(masking_utils.origin_create_causal_mask).parameters:
+                if has_signature_parameter(masking_utils.origin_create_causal_mask, 'cache_position'):
                     cache_position_or_past_key_values = torch.arange(
                         0,
                         input_embeds.shape[1],

--- a/src/twinkle/patch/gdn_padding_free.py
+++ b/src/twinkle/patch/gdn_padding_free.py
@@ -1,12 +1,11 @@
-import inspect
 import torch
 import transformers
-from functools import lru_cache
 from packaging.version import Version
 from transformers.utils.import_utils import is_flash_linear_attention_available
 from typing import Optional
 
 from twinkle.patch import Patch
+from twinkle.utils.utils import call_with_supported_kwargs
 
 
 def _is_qwen35_model(hf_config) -> bool:
@@ -35,21 +34,6 @@ def _get_flash_linear_attention_kernels():
     from fla.ops.gated_delta_rule import chunk_gated_delta_rule
 
     return causal_conv1d, chunk_gated_delta_rule
-
-
-@lru_cache(maxsize=None)
-def _supported_kwarg_names(fn):
-    signature = inspect.signature(fn)
-    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()):
-        return None
-    return frozenset(signature.parameters)
-
-
-def _call_with_supported_kwargs(fn, *args, **kwargs):
-    supported_kwargs = _supported_kwarg_names(fn)
-    if supported_kwargs is not None:
-        kwargs = {key: value for key, value in kwargs.items() if key in supported_kwargs}
-    return fn(*args, **kwargs)
 
 
 def _needs_chunk_gated_delta_rule_cu_seqlens_patch() -> bool:
@@ -89,7 +73,7 @@ def _patch_gdn_kernels_for_cu_seqlens(
     if patch_chunk_rule:
         mod.chunk_gated_delta_rule = chunk_gated_delta_rule_wrapper
     try:
-        return _call_with_supported_kwargs(origin_forward, mod, *forward_args, **forward_kwargs)
+        return call_with_supported_kwargs(origin_forward, mod, *forward_args, **forward_kwargs)
     finally:
         mod.causal_conv1d_fn = old_conv_fn
         if patch_chunk_rule:
@@ -125,7 +109,7 @@ class GatedDeltaNetPaddingFreePatch(Patch):
                 **extra_kwargs,
             ):
                 if getattr(layer, 'layer_type', None) != 'linear_attention':
-                    return _call_with_supported_kwargs(
+                    return call_with_supported_kwargs(
                         origin_decoder_forward,
                         layer,
                         hidden_states=hidden_states,
@@ -175,7 +159,7 @@ class GatedDeltaNetPaddingFreePatch(Patch):
                 **extra_kwargs,
             ):
                 if cu_seq_lens_q is None:
-                    return _call_with_supported_kwargs(
+                    return call_with_supported_kwargs(
                         origin_forward,
                         mod,
                         hidden_states,

--- a/src/twinkle/patch/gdn_padding_free.py
+++ b/src/twinkle/patch/gdn_padding_free.py
@@ -1,6 +1,8 @@
+import inspect
+from typing import Optional
+
 import torch
 from transformers.utils.import_utils import is_flash_linear_attention_available
-from typing import Optional
 
 from twinkle.patch import Patch
 
@@ -31,6 +33,13 @@ def _get_flash_linear_attention_kernels():
     from fla.ops.gated_delta_rule import chunk_gated_delta_rule
 
     return causal_conv1d, chunk_gated_delta_rule
+
+
+def _call_with_supported_kwargs(fn, *args, **kwargs):
+    signature = inspect.signature(fn)
+    if not any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()):
+        kwargs = {key: value for key, value in kwargs.items() if key in signature.parameters}
+    return fn(*args, **kwargs)
 
 
 def _patch_gdn_kernels_for_cu_seqlens(
@@ -64,7 +73,7 @@ def _patch_gdn_kernels_for_cu_seqlens(
     mod.causal_conv1d_fn = causal_conv1d_wrapper
     mod.chunk_gated_delta_rule = chunk_gated_delta_rule_wrapper
     try:
-        return origin_forward(mod, *forward_args, **forward_kwargs)
+        return _call_with_supported_kwargs(origin_forward, mod, *forward_args, **forward_kwargs)
     finally:
         mod.causal_conv1d_fn = old_conv_fn
         mod.chunk_gated_delta_rule = old_chunk_rule
@@ -147,7 +156,8 @@ class GatedDeltaNetPaddingFreePatch(Patch):
                 **extra_kwargs,
             ):
                 if cu_seq_lens_q is None:
-                    return origin_forward(
+                    return _call_with_supported_kwargs(
+                        origin_forward,
                         mod,
                         hidden_states,
                         cache_params=cache_params,

--- a/src/twinkle/patch/gdn_padding_free.py
+++ b/src/twinkle/patch/gdn_padding_free.py
@@ -1,6 +1,7 @@
 import inspect
 import torch
 import transformers
+from functools import lru_cache
 from packaging.version import Version
 from transformers.utils.import_utils import is_flash_linear_attention_available
 from typing import Optional
@@ -36,10 +37,18 @@ def _get_flash_linear_attention_kernels():
     return causal_conv1d, chunk_gated_delta_rule
 
 
-def _call_with_supported_kwargs(fn, *args, **kwargs):
+@lru_cache(maxsize=None)
+def _supported_kwarg_names(fn):
     signature = inspect.signature(fn)
-    if not any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()):
-        kwargs = {key: value for key, value in kwargs.items() if key in signature.parameters}
+    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()):
+        return None
+    return frozenset(signature.parameters)
+
+
+def _call_with_supported_kwargs(fn, *args, **kwargs):
+    supported_kwargs = _supported_kwarg_names(fn)
+    if supported_kwargs is not None:
+        kwargs = {key: value for key, value in kwargs.items() if key in supported_kwargs}
     return fn(*args, **kwargs)
 
 

--- a/src/twinkle/patch/gdn_padding_free.py
+++ b/src/twinkle/patch/gdn_padding_free.py
@@ -1,5 +1,7 @@
 import inspect
 import torch
+from packaging.version import Version
+from transformers import __version__ as transformers_version
 from transformers.utils.import_utils import is_flash_linear_attention_available
 from typing import Optional
 
@@ -41,11 +43,8 @@ def _call_with_supported_kwargs(fn, *args, **kwargs):
     return fn(*args, **kwargs)
 
 
-def _supports_native_padding_free(Qwen3_5GatedDeltaNet) -> bool:
-    try:
-        return 'cu_seq_lens_q' in inspect.getsource(Qwen3_5GatedDeltaNet.forward)
-    except (OSError, TypeError):
-        return False
+def _supports_native_padding_free() -> bool:
+    return Version(Version(transformers_version).base_version) >= Version('5.9.0')
 
 
 def _patch_gdn_kernels_for_cu_seqlens(
@@ -99,7 +98,7 @@ class GatedDeltaNetPaddingFreePatch(Patch):
         if getattr(Qwen3_5GatedDeltaNet, '_twinkle_sp_linear_patched', False):
             return
         module._twinkle_gdn_padding_free_patched = True
-        if _supports_native_padding_free(Qwen3_5GatedDeltaNet):
+        if _supports_native_padding_free():
             return
 
         if not getattr(Qwen3_5DecoderLayer, '_twinkle_padding_free_cu_seqlens_patched', False):

--- a/src/twinkle/patch/gdn_padding_free.py
+++ b/src/twinkle/patch/gdn_padding_free.py
@@ -1,5 +1,7 @@
 import inspect
 import torch
+import transformers
+from packaging.version import Version
 from transformers.utils.import_utils import is_flash_linear_attention_available
 from typing import Optional
 
@@ -41,10 +43,15 @@ def _call_with_supported_kwargs(fn, *args, **kwargs):
     return fn(*args, **kwargs)
 
 
+def _needs_chunk_gated_delta_rule_cu_seqlens_patch() -> bool:
+    return Version(transformers.__version__) < Version('5.9.0')
+
+
 def _patch_gdn_kernels_for_cu_seqlens(
     mod: torch.nn.Module,
     *,
     cu_seqlens: torch.Tensor,
+    patch_chunk_rule: bool,
     origin_forward,
     forward_args,
     forward_kwargs,
@@ -70,12 +77,14 @@ def _patch_gdn_kernels_for_cu_seqlens(
         return chunk_gated_delta_rule(query, key, value, **kwargs)
 
     mod.causal_conv1d_fn = causal_conv1d_wrapper
-    mod.chunk_gated_delta_rule = chunk_gated_delta_rule_wrapper
+    if patch_chunk_rule:
+        mod.chunk_gated_delta_rule = chunk_gated_delta_rule_wrapper
     try:
         return _call_with_supported_kwargs(origin_forward, mod, *forward_args, **forward_kwargs)
     finally:
         mod.causal_conv1d_fn = old_conv_fn
-        mod.chunk_gated_delta_rule = old_chunk_rule
+        if patch_chunk_rule:
+            mod.chunk_gated_delta_rule = old_chunk_rule
 
 
 class GatedDeltaNetPaddingFreePatch(Patch):
@@ -145,6 +154,7 @@ class GatedDeltaNetPaddingFreePatch(Patch):
 
         if not getattr(Qwen3_5GatedDeltaNet, '_twinkle_padding_free_gdn_patched', False):
             origin_forward = Qwen3_5GatedDeltaNet.forward
+            patch_chunk_rule = _needs_chunk_gated_delta_rule_cu_seqlens_patch()
 
             def forward(
                 mod,
@@ -168,12 +178,14 @@ class GatedDeltaNetPaddingFreePatch(Patch):
                 return _patch_gdn_kernels_for_cu_seqlens(
                     mod,
                     cu_seqlens=cu_seq_lens_q,
+                    patch_chunk_rule=patch_chunk_rule,
                     origin_forward=origin_forward,
                     forward_args=(hidden_states, ),
                     forward_kwargs={
                         'cache_params': cache_params,
                         'cache_position': cache_position,
                         'attention_mask': attention_mask,
+                        'cu_seq_lens_q': cu_seq_lens_q,
                         **extra_kwargs,
                     },
                 )

--- a/src/twinkle/patch/gdn_padding_free.py
+++ b/src/twinkle/patch/gdn_padding_free.py
@@ -1,8 +1,7 @@
 import inspect
-from typing import Optional
-
 import torch
 from transformers.utils.import_utils import is_flash_linear_attention_available
+from typing import Optional
 
 from twinkle.patch import Patch
 
@@ -40,6 +39,13 @@ def _call_with_supported_kwargs(fn, *args, **kwargs):
     if not any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()):
         kwargs = {key: value for key, value in kwargs.items() if key in signature.parameters}
     return fn(*args, **kwargs)
+
+
+def _supports_native_padding_free(Qwen3_5GatedDeltaNet) -> bool:
+    try:
+        return 'cu_seq_lens_q' in inspect.getsource(Qwen3_5GatedDeltaNet.forward)
+    except (OSError, TypeError):
+        return False
 
 
 def _patch_gdn_kernels_for_cu_seqlens(
@@ -93,6 +99,8 @@ class GatedDeltaNetPaddingFreePatch(Patch):
         if getattr(Qwen3_5GatedDeltaNet, '_twinkle_sp_linear_patched', False):
             return
         module._twinkle_gdn_padding_free_patched = True
+        if _supports_native_padding_free(Qwen3_5GatedDeltaNet):
+            return
 
         if not getattr(Qwen3_5DecoderLayer, '_twinkle_padding_free_cu_seqlens_patched', False):
             origin_decoder_forward = Qwen3_5DecoderLayer.forward
@@ -108,7 +116,8 @@ class GatedDeltaNetPaddingFreePatch(Patch):
                 **extra_kwargs,
             ):
                 if getattr(layer, 'layer_type', None) != 'linear_attention':
-                    return origin_decoder_forward(
+                    return _call_with_supported_kwargs(
+                        origin_decoder_forward,
                         layer,
                         hidden_states=hidden_states,
                         position_embeddings=position_embeddings,

--- a/src/twinkle/patch/gdn_padding_free.py
+++ b/src/twinkle/patch/gdn_padding_free.py
@@ -1,7 +1,5 @@
 import inspect
 import torch
-from packaging.version import Version
-from transformers import __version__ as transformers_version
 from transformers.utils.import_utils import is_flash_linear_attention_available
 from typing import Optional
 
@@ -41,10 +39,6 @@ def _call_with_supported_kwargs(fn, *args, **kwargs):
     if not any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()):
         kwargs = {key: value for key, value in kwargs.items() if key in signature.parameters}
     return fn(*args, **kwargs)
-
-
-def _supports_native_padding_free() -> bool:
-    return Version(Version(transformers_version).base_version) >= Version('5.9.0')
 
 
 def _patch_gdn_kernels_for_cu_seqlens(
@@ -98,8 +92,6 @@ class GatedDeltaNetPaddingFreePatch(Patch):
         if getattr(Qwen3_5GatedDeltaNet, '_twinkle_sp_linear_patched', False):
             return
         module._twinkle_gdn_padding_free_patched = True
-        if _supports_native_padding_free():
-            return
 
         if not getattr(Qwen3_5DecoderLayer, '_twinkle_padding_free_cu_seqlens_patched', False):
             origin_decoder_forward = Qwen3_5DecoderLayer.forward

--- a/src/twinkle/utils/utils.py
+++ b/src/twinkle/utils/utils.py
@@ -1,8 +1,10 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
 import fnmatch
 import glob
+import inspect
 import os
 import shutil
+from functools import lru_cache
 
 
 def deep_getattr(obj, attr: str, default=None):
@@ -15,6 +17,24 @@ def deep_getattr(obj, attr: str, default=None):
         else:
             obj = getattr(obj, a, default)
     return obj
+
+
+@lru_cache(maxsize=None)
+def signature_info(fn):
+    signature = inspect.signature(fn)
+    accepts_kwargs = any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values())
+    return accepts_kwargs, frozenset(signature.parameters)
+
+
+def has_signature_parameter(fn, name: str) -> bool:
+    return name in signature_info(fn)[1]
+
+
+def call_with_supported_kwargs(fn, *args, **kwargs):
+    accepts_kwargs, parameters = signature_info(fn)
+    if not accepts_kwargs:
+        kwargs = {key: value for key, value in kwargs.items() if key in parameters}
+    return fn(*args, **kwargs)
 
 
 def copy_files_by_pattern(source_dir, dest_dir, patterns, exclude_patterns=None):


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

This PR fixes padding-free and sequence-parallel compatibility issues with newer Transformers versions.

Main changes:
 when transformers >5.3.0 ,cache_positoins is removed in  [this pr](https://github.com/huggingface/transformers/pull/44181),so we :
- Support forward methods whose kwargs are incompatible across Transformers versions.
- Add compatibility handling for Qwen3.5 GatedDeltaNet padding-free training.
- Skip Twinkle GDN padding-free patch when Transformers version natively supports Qwen3.5 `cu_seq_lens_q` in [this pr](https://github.com/huggingface/transformers/pull/45034)
- Adapt sequence-parallel causal mask patching for both old and new Transformers mask APIs.


## Experiment results

end to end test results as followed:
sp:
Model | Transformers | Attention implementation | results
-- | -- | -- | --
Qwen3-0.6B | 5.3.0 | flash_attention_2 | pass
Qwen3-0.6B | 5.3.0 | sdpa | pass
Qwen3-0.6B | 5.8.0 | flash_attention_2 | pass
Qwen3-0.6B | 5.8.0 | sdpa | pass
Qwen3.5-4B | 5.3.0 | flash_attention_2 | pass
Qwen3.5-4B | 5.3.0 | sdpa | pass



padding_free :
Model | Transformers | Attention implementation | results
-- | -- | -- | --
Qwen3.5-4B | 5.3.0 | flash_attention_2 | pass
Qwen3.5-4B | 5.9.0+ | flash_attention_2 | pass