### PR TITLE
fix: use MultiLora state dict is null  when saving adapters

### DIFF
--- a/src/twinkle/model/transformers/multi_lora_transformers.py
+++ b/src/twinkle/model/transformers/multi_lora_transformers.py
@@ -8,7 +8,7 @@ from torch.optim.lr_scheduler import LRScheduler
 from transformers import AutoModelForCausalLM, PretrainedConfig, PreTrainedModel
 from typing import Any, Callable, Dict, List, Literal, Optional, Type, Union
 
-from twinkle import DeviceMesh, remote_class, remote_function, template
+from twinkle import DeviceMesh, remote_class, remote_function, template, torch_util
 from twinkle.data_format import InputFeature, Trajectory
 from twinkle.hub import HubOperation
 from twinkle.infra import collect_tensor_dict
@@ -234,6 +234,10 @@ class MultiLoraTransformersModel(TransformersModel, PreTrainedModel):
     def get_state_dict(self, **kwargs):
         self._check_adapter_valid(kwargs.get('adapter_name'))
         return self.multi_adapter.get_state_dict(kwargs.get('adapter_name'))
+
+    def _get_adapter_state_dict_for_save(self, adapter_name: str) -> dict:
+        adapter_state = self.multi_adapter.get_state_dict(adapter_name)
+        return {key: torch_util.to_local_tensor(value).cpu() for key, value in adapter_state.items()}
 
     @remote_function(collect='first')
     def save(self, name, output_dir: Optional[str] = None, interval=1, **kwargs):

--- a/src/twinkle/model/transformers/transformers.py
+++ b/src/twinkle/model/transformers/transformers.py
@@ -912,12 +912,7 @@ class TransformersModel(TwinkleModel, PreTrainedModel, CheckpointEngineMixin):
             # Full model save
             processed_state_dict = self.strategy.get_full_state_dict(self.model)
         else:
-            # LoRA adapter save. Avoid collecting the full base model for large FSDP/EP jobs.
-            adapter_state = self.strategy.get_adapter_state_dict(self.model, adapter_name)
-            adapter_suffix = f'.{adapter_name}.'
-            for key, value in adapter_state.items():
-                normalized = key.replace(adapter_suffix, '.')
-                processed_state_dict[normalized] = value
+            processed_state_dict = self._get_adapter_state_dict_for_save(adapter_name)
 
         if isinstance(model, PeftModel):
             if Platform.is_master():
@@ -937,6 +932,17 @@ class TransformersModel(TwinkleModel, PreTrainedModel, CheckpointEngineMixin):
             )
 
         return checkpoint_dir
+
+    def _get_adapter_state_dict_for_save(self, adapter_name: str) -> dict:
+        """Return PEFT-normalized adapter state dict for saving."""
+        # Avoid collecting the full base model for large FSDP/EP jobs.
+        adapter_state = self.strategy.get_adapter_state_dict(self.model, adapter_name)
+        adapter_suffix = f'.{adapter_name}.'
+        processed_state_dict = {}
+        for key, value in adapter_state.items():
+            normalized = key.replace(adapter_suffix, '.')
+            processed_state_dict[normalized] = value
+        return processed_state_dict
 
     def _save_optimizer(self, output_dir, **kwargs):
         adapter_name = kwargs.pop('adapter_name', _default_adapter_name)


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

This PR 修复了这个 [issue](https://github.com/modelscope/twinkle/issues/211)中空的`adapter_model.safetensors` 保存问题
因为在这个[pr](https://github.com/modelscope/twinkle/pull/198/changes)中修改了保存的逻辑
<img width="2116" height="1134" alt="a3e3039dfbf649429411ee4c62ffe52f" src="https://github.com/user-attachments/assets/a767c372-4746-4207-ac5c-035f3b398ab2" />


本 PR 在 `TransformersModel` 中抽出保存 adapter state 的 hook：

- 普通 `TransformersModel` 仍使用 strategy 收集 adapter state。
- `MultiLoraTransformersModel` override 该 hook，复用 `multi_adapter.get_state_dict(adapter_name)`，这样 tenant-to-slot 槽位映射才会生效，所以 MultiLora 保存不会因为adapter name 不匹配导致的权重为空问题

## Experiment results

<img width="858" height="261" alt="6ceba240b24a3278d90597cd5388db35" src="https://github.com/user-attachments/assets/326fb1a8-d09c-449b-aed9-58ecd01aa6e6" />
