### PR TITLE
feat: support auto-resolved template model IDs

### DIFF
--- a/client_tools/client_generator.py
+++ b/client_tools/client_generator.py
@@ -441,6 +441,7 @@ def generate_models():
 from pathlib import Path
 import time
 from twinkle_client.http import http_get, http_post
+from twinkle_client.common.template_model_id import resolve_template_model_id
 from twinkle_client.types.model import (
     CalculateLossResponse,
     CalculateMetricResponse,
@@ -650,9 +651,11 @@ class MultiLoraTransformersModel:
 
     def set_template(self, template_cls: str, **kwargs) -> None:
         """Set the template for data processing."""
+        explicit_model_id = kwargs.pop('model_id', None)
+        model_id = resolve_template_model_id(self.model_id, explicit_model_id)
         response = http_post(
             url=f'{self.server_url}/set_template',
-            json_data={'template_cls': template_cls, 'adapter_name': self.adapter_name, 'model_id': self.model_id, **kwargs}
+            json_data={'template_cls': template_cls, 'adapter_name': self.adapter_name, 'model_id': model_id, **kwargs}
         )
         response.raise_for_status()
 
@@ -760,6 +763,7 @@ def generate_samplers():
 
     sampler_code = AUTO_GEN_WARNING + '''from typing import Any, Dict, List, Optional, Union
 from twinkle_client.http import http_post
+from twinkle_client.common.template_model_id import resolve_template_model_id
 from twinkle.sampler.base import Sampler
 from twinkle_client.types.sampler import AddAdapterResponse, SampleResponseModel, SetTemplateResponse
 from peft import PeftConfig
@@ -781,6 +785,7 @@ class vLLMSampler(Sampler):
         self.adapter_name = None
         if '://' in model_id:
             model_id = model_id.split('://')[1]
+        self.model_id = model_id
         self.server_url = f'{self.server_url}/sampler/{model_id}/twinkle'
         response = http_post(
             url=f'{self.server_url}/create',
@@ -838,9 +843,11 @@ class vLLMSampler(Sampler):
 
     def set_template(self, template_cls: str, adapter_name: str = '', **kwargs) -> SetTemplateResponse:
         """Set the template for encoding trajectories."""
+        explicit_model_id = kwargs.pop('model_id', None)
+        model_id = resolve_template_model_id(self.model_id, explicit_model_id)
         response = http_post(
             url=f'{self.server_url}/set_template',
-            json_data={'template_cls': template_cls, 'adapter_name': adapter_name, **kwargs}
+            json_data={'template_cls': template_cls, 'adapter_name': adapter_name, 'model_id': model_id, **kwargs}
         )
         response.raise_for_status()
         return SetTemplateResponse(**response.json())

--- a/client_tools/client_generator.py
+++ b/client_tools/client_generator.py
@@ -467,9 +467,9 @@ class MultiLoraTransformersModel:
         from twinkle_client.http import get_base_url
         self.server_url = get_base_url()
 
-        self.model_id = model_id
         if '://' in model_id:
             model_id = model_id.split('://')[1]
+        self.model_id = model_id
         self.server_url = f'{self.server_url}/model/{model_id}/twinkle'
         self.adapter_name = None
         response = http_post(
@@ -652,6 +652,8 @@ class MultiLoraTransformersModel:
     def set_template(self, template_cls: str, **kwargs) -> None:
         """Set the template for data processing."""
         explicit_model_id = kwargs.pop('model_id', None)
+        if explicit_model_id and '://' in explicit_model_id:
+            explicit_model_id = explicit_model_id.split('://')[1]
         model_id = resolve_template_model_id(self.model_id, explicit_model_id)
         response = http_post(
             url=f'{self.server_url}/set_template',
@@ -844,6 +846,8 @@ class vLLMSampler(Sampler):
     def set_template(self, template_cls: str, adapter_name: str = '', **kwargs) -> SetTemplateResponse:
         """Set the template for encoding trajectories."""
         explicit_model_id = kwargs.pop('model_id', None)
+        if explicit_model_id and '://' in explicit_model_id:
+            explicit_model_id = explicit_model_id.split('://')[1]
         model_id = resolve_template_model_id(self.model_id, explicit_model_id)
         response = http_post(
             url=f'{self.server_url}/set_template',

--- a/src/twinkle/server/launcher.py
+++ b/src/twinkle/server/launcher.py
@@ -55,6 +55,12 @@ def _normalize_supported_model_item(item: Any) -> dict[str, Any] | None:
             return None
         return dict(item)
     if hasattr(item, 'model_name'):
+        if hasattr(item, 'model_dump'):
+            normalized = item.model_dump()
+            return normalized if normalized.get('model_name') else None
+        if hasattr(item, 'dict'):
+            normalized = item.dict()
+            return normalized if normalized.get('model_name') else None
         model_name = getattr(item, 'model_name', None)
         if not model_name:
             return None

--- a/src/twinkle/server/launcher.py
+++ b/src/twinkle/server/launcher.py
@@ -24,12 +24,91 @@ from __future__ import annotations
 import signal
 import threading
 from pathlib import Path
-from typing import Any, Callable, Dict, NoReturn, Optional, Union
+from typing import Any, Callable
 
 from twinkle import get_logger
 from twinkle.server.utils.ray_serve_patch import apply_ray_serve_patches, get_runtime_env_for_patches
 
 logger = get_logger()
+
+
+def _extract_logical_model_name(route_prefix: str, import_path: str) -> str | None:
+    """Extract the logical model name from a model/sampler route prefix."""
+    route_parts = [part for part in str(route_prefix or '').strip('/').split('/') if part]
+    service_part = 'model' if import_path == 'model' else 'sampler' if import_path == 'sampler' else None
+    if service_part is None:
+        return None
+    if service_part not in route_parts:
+        return None
+    service_index = route_parts.index(service_part)
+    logical_parts = route_parts[service_index + 1:]
+    return '/'.join(logical_parts) or None
+
+
+def _normalize_supported_model_item(item: Any) -> dict[str, Any] | None:
+    """Normalize supported model config entries to plain dicts."""
+    if isinstance(item, str):
+        return {'model_name': item}
+    if isinstance(item, dict):
+        model_name = item.get('model_name')
+        if not model_name:
+            return None
+        return dict(item)
+    if hasattr(item, 'model_name'):
+        model_name = getattr(item, 'model_name', None)
+        if not model_name:
+            return None
+        template_init_model_id = getattr(item, 'template_init_model_id', None)
+        return {
+            'model_name': model_name,
+            'template_init_model_id': template_init_model_id,
+        }
+    return None
+
+
+def _derive_supported_models_from_applications(applications: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    """Build logical-model capabilities from model/sampler application config."""
+    deduped: dict[str, dict[str, Any]] = {}
+    for app_config in applications or []:
+        if not isinstance(app_config, dict):
+            app_config = dict(app_config)
+        import_path = app_config.get('import_path')
+        if import_path not in {'model', 'sampler'}:
+            continue
+        args = app_config.get('args', {}) or {}
+        template_init_model_id = args.get('model_id')
+        logical_model_name = _extract_logical_model_name(app_config.get('route_prefix', ''), import_path)
+        if not logical_model_name:
+            continue
+        existing = deduped.setdefault(logical_model_name, {'model_name': logical_model_name})
+        # Prefer sampler model_id when available because self_host set_template targets sampler.
+        if import_path == 'sampler' and template_init_model_id:
+            existing['template_init_model_id'] = template_init_model_id
+        elif not existing.get('template_init_model_id') and template_init_model_id:
+            existing['template_init_model_id'] = template_init_model_id
+    return list(deduped.values())
+
+
+def _merge_supported_models(configured_supported_models: list[Any] | None,
+                            applications: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    """Merge explicit supported_models with model/sampler-derived capabilities."""
+    derived_models = _derive_supported_models_from_applications(applications)
+    derived_by_name = {item['model_name']: item for item in derived_models}
+    merged: dict[str, dict[str, Any]] = {}
+
+    for item in configured_supported_models or []:
+        normalized = _normalize_supported_model_item(item)
+        if not normalized:
+            continue
+        derived = derived_by_name.get(normalized['model_name'])
+        if derived and not normalized.get('template_init_model_id'):
+            normalized['template_init_model_id'] = derived.get('template_init_model_id')
+        merged[normalized['model_name']] = normalized
+
+    for item in derived_models:
+        merged.setdefault(item['model_name'], item)
+
+    return list(merged.values())
 
 
 class ServerLauncher:
@@ -177,7 +256,7 @@ class ServerLauncher:
         name = app_config.get('name', 'app')
         route_prefix = app_config.get('route_prefix', '/')
         import_path = app_config.get('import_path', 'server')
-        args = app_config.get('args', {}) or {}
+        args = dict(app_config.get('args', {}) or {})
         deployments = app_config.get('deployments', [])
 
         logger.info(f'Starting {name} at {route_prefix}...')
@@ -197,6 +276,9 @@ class ServerLauncher:
         http_options = self.config.get('http_options', {})
         if import_path == 'server' and http_options:
             args['http_options'] = http_options
+        if import_path == 'server':
+            args['supported_models'] = _merge_supported_models(
+                args.get('supported_models'), self.config.get('applications', []))
 
         app = builder(deploy_options=deploy_options, **{k: v for k, v in args.items()})
 

--- a/src/twinkle_client/common/template_model_id.py
+++ b/src/twinkle_client/common/template_model_id.py
@@ -12,6 +12,7 @@ def _get_server_capabilities(refresh: bool = False) -> GetServerCapabilitiesResp
     base_url = get_base_url()
     if refresh or base_url not in _SERVER_CAPABILITIES_CACHE:
         response = http_get(f'{base_url}/twinkle/get_server_capabilities')
+        response.raise_for_status()
         _SERVER_CAPABILITIES_CACHE[base_url] = GetServerCapabilitiesResponse(**response.json())
     return _SERVER_CAPABILITIES_CACHE[base_url]
 
@@ -28,7 +29,10 @@ def resolve_template_model_id(model_name: str, explicit_model_id: str | None = N
     if explicit_model_id is not None:
         return explicit_model_id
 
-    supported_model = get_supported_model_by_name(model_name)
-    if supported_model and supported_model.template_init_model_id:
-        return supported_model.template_init_model_id
+    try:
+        supported_model = get_supported_model_by_name(model_name)
+        if supported_model and supported_model.template_init_model_id:
+            return supported_model.template_init_model_id
+    except Exception:
+        pass
     return model_name

--- a/src/twinkle_client/common/template_model_id.py
+++ b/src/twinkle_client/common/template_model_id.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from twinkle_client.http import get_base_url, http_get
+from twinkle_client.types.server import GetServerCapabilitiesResponse, SupportedModel
+
+_SERVER_CAPABILITIES_CACHE: Dict[str, GetServerCapabilitiesResponse] = {}
+
+
+def _get_server_capabilities(refresh: bool = False) -> GetServerCapabilitiesResponse:
+    base_url = get_base_url()
+    if refresh or base_url not in _SERVER_CAPABILITIES_CACHE:
+        response = http_get(f'{base_url}/twinkle/get_server_capabilities')
+        _SERVER_CAPABILITIES_CACHE[base_url] = GetServerCapabilitiesResponse(**response.json())
+    return _SERVER_CAPABILITIES_CACHE[base_url]
+
+
+def get_supported_model_by_name(model_name: str, refresh: bool = False) -> SupportedModel | None:
+    capabilities = _get_server_capabilities(refresh=refresh)
+    for supported_model in capabilities.supported_models:
+        if supported_model.model_name == model_name:
+            return supported_model
+    return None
+
+
+def resolve_template_model_id(model_name: str, explicit_model_id: str | None = None) -> str:
+    if explicit_model_id is not None:
+        return explicit_model_id
+
+    supported_model = get_supported_model_by_name(model_name)
+    if supported_model and supported_model.template_init_model_id:
+        return supported_model.template_init_model_id
+    return model_name

--- a/src/twinkle_client/model/multi_lora_transformers.py
+++ b/src/twinkle_client/model/multi_lora_transformers.py
@@ -38,9 +38,9 @@ class MultiLoraTransformersModel:
         from twinkle_client.http import get_base_url
         self.server_url = get_base_url()
 
-        self.model_id = model_id
         if '://' in model_id:
             model_id = model_id.split('://')[1]
+        self.model_id = model_id
         self.server_url = f'{self.server_url}/model/{model_id}/twinkle'
         self.adapter_name = None
         response = http_post(
@@ -223,6 +223,8 @@ class MultiLoraTransformersModel:
     def set_template(self, template_cls: str, **kwargs) -> None:
         """Set the template for data processing."""
         explicit_model_id = kwargs.pop('model_id', None)
+        if explicit_model_id and '://' in explicit_model_id:
+            explicit_model_id = explicit_model_id.split('://')[1]
         model_id = resolve_template_model_id(self.model_id, explicit_model_id)
         response = http_post(
             url=f'{self.server_url}/set_template',

--- a/src/twinkle_client/model/multi_lora_transformers.py
+++ b/src/twinkle_client/model/multi_lora_transformers.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Optional
 from pathlib import Path
 import time
 from twinkle_client.http import http_get, http_post
+from twinkle_client.common.template_model_id import resolve_template_model_id
 from twinkle_client.types.model import (
     CalculateLossResponse,
     CalculateMetricResponse,
@@ -221,9 +222,11 @@ class MultiLoraTransformersModel:
 
     def set_template(self, template_cls: str, **kwargs) -> None:
         """Set the template for data processing."""
+        explicit_model_id = kwargs.pop('model_id', None)
+        model_id = resolve_template_model_id(self.model_id, explicit_model_id)
         response = http_post(
             url=f'{self.server_url}/set_template',
-            json_data={'template_cls': template_cls, 'adapter_name': self.adapter_name, 'model_id': self.model_id, **kwargs}
+            json_data={'template_cls': template_cls, 'adapter_name': self.adapter_name, 'model_id': model_id, **kwargs}
         )
         response.raise_for_status()
 

--- a/src/twinkle_client/sampler/vllm_sampler.py
+++ b/src/twinkle_client/sampler/vllm_sampler.py
@@ -91,6 +91,8 @@ class vLLMSampler(Sampler):
     def set_template(self, template_cls: str, adapter_name: str = '', **kwargs) -> SetTemplateResponse:
         """Set the template for encoding trajectories."""
         explicit_model_id = kwargs.pop('model_id', None)
+        if explicit_model_id and '://' in explicit_model_id:
+            explicit_model_id = explicit_model_id.split('://')[1]
         model_id = resolve_template_model_id(self.model_id, explicit_model_id)
         response = http_post(
             url=f'{self.server_url}/set_template',

--- a/src/twinkle_client/sampler/vllm_sampler.py
+++ b/src/twinkle_client/sampler/vllm_sampler.py
@@ -10,6 +10,7 @@
 # ============================================================================
 from typing import Any, Dict, List, Optional, Union
 from twinkle_client.http import http_post
+from twinkle_client.common.template_model_id import resolve_template_model_id
 from twinkle.sampler.base import Sampler
 from twinkle_client.types.sampler import AddAdapterResponse, SampleResponseModel, SetTemplateResponse
 from peft import PeftConfig
@@ -31,6 +32,7 @@ class vLLMSampler(Sampler):
         self.adapter_name = None
         if '://' in model_id:
             model_id = model_id.split('://')[1]
+        self.model_id = model_id
         self.server_url = f'{self.server_url}/sampler/{model_id}/twinkle'
         response = http_post(
             url=f'{self.server_url}/create',
@@ -88,9 +90,11 @@ class vLLMSampler(Sampler):
 
     def set_template(self, template_cls: str, adapter_name: str = '', **kwargs) -> SetTemplateResponse:
         """Set the template for encoding trajectories."""
+        explicit_model_id = kwargs.pop('model_id', None)
+        model_id = resolve_template_model_id(self.model_id, explicit_model_id)
         response = http_post(
             url=f'{self.server_url}/set_template',
-            json_data={'template_cls': template_cls, 'adapter_name': adapter_name, **kwargs}
+            json_data={'template_cls': template_cls, 'adapter_name': adapter_name, 'model_id': model_id, **kwargs}
         )
         response.raise_for_status()
         return SetTemplateResponse(**response.json())

--- a/src/twinkle_client/types/server.py
+++ b/src/twinkle_client/types/server.py
@@ -7,6 +7,7 @@ from typing import Any, List, Optional
 class SupportedModel(BaseModel):
     """Information about a supported model."""
     model_name: str
+    template_init_model_id: Optional[str] = None
 
 
 class GetServerCapabilitiesResponse(BaseModel):


### PR DESCRIPTION
# PR type
- [ ] Bug Fix
- [x] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

Write the detail information belongs to this PR.
- add `template_init_model_id` to `SupportedModel` to support configuring the target model ID used for template initialization
- add the `template_model_id` helper module, preferring an explicit model ID and otherwise resolving it from server capabilities
- update `MultiLoraTransformersModel.set_template` and `vLLMSampler.set_template` to replace model ID passing with the new resolution flow
## Experiment results

Paste your experiment result here(if needed).
