### PR TITLE
fix deeseek v4 template

### DIFF
--- a/src/twinkle/template/base.py
+++ b/src/twinkle/template/base.py
@@ -79,6 +79,9 @@ class Template:
         if 'qwen' in mid:
             from .qwen import QwenTemplate
             return QwenTemplate.parse(self, decoded)
+        if 'deepseek' in mid:
+            from .deepseek_v4 import DeepseekV4Template
+            return DeepseekV4Template.parse(self, decoded)
         # TODO: Other models (Llama3, OpenAI JSON, …) — add a parser in
         # ``tool_call_parser.py`` and extend this dispatch.
         return []
@@ -89,6 +92,9 @@ class Template:
         if 'qwen' in mid:
             from .qwen import QwenTemplate
             return QwenTemplate.clean(self, decoded)
+        if 'deepseek' in mid:
+            from .deepseek_v4 import DeepseekV4Template
+            return DeepseekV4Template.clean(self, decoded)
         # TODO: Other models
         return (decoded or '').rstrip()
 
@@ -714,9 +720,10 @@ class Template:
 
     def format_trajectory(self, trajectory: Trajectory, add_default_system: bool = False) -> Trajectory:
         current = [trajectory]
-        for pipeline in self.pre_pipeline:
-            if not add_default_system and pipeline == self._add_default_system:
+        for pipeline_name in self.pre_pipeline_names:
+            if not add_default_system and pipeline_name == '_add_default_system':
                 continue
+            pipeline: Callable[[Trajectory], List[Trajectory]] = getattr(self, pipeline_name)
             next_batch = []
             for traj in current:
                 next_batch.extend(pipeline(traj))

--- a/src/twinkle/template/deepseek_v4.py
+++ b/src/twinkle/template/deepseek_v4.py
@@ -1,12 +1,15 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
 import copy
+import json
+import re
 import torch
 from transformers import AutoConfig, PreTrainedTokenizerFast
 from typing import Any, Dict, List, Literal, Optional
 
 from twinkle.hub import HubOperation
 from .base import Template
-from .deepseek_v4_encoding import encode_messages
+from .deepseek_v4_encoding import (dsml_token, encode_messages, eos_token, parse_message_from_completion_text,
+                                   tool_calls_block_name)
 
 
 def get_deepseek_v4_tokenizer(tokenizer):
@@ -99,6 +102,9 @@ def get_deepseek_v4_tokenizer(tokenizer):
 
 class DeepseekV4Template(Template):
 
+    _TOOL_CALLS_START = f'<{dsml_token}{tool_calls_block_name}>'
+    _TOOL_CALLS_END = f'</{dsml_token}{tool_calls_block_name}>'
+
     def __init__(
         self,
         model_id: str,
@@ -109,6 +115,7 @@ class DeepseekV4Template(Template):
         enable_thinking: bool = True,
         **kwargs,
     ):
+        self.model_id = model_id
         model_id = HubOperation.download_model(model_id, ignore_model=True)
         base_tokenizer = PreTrainedTokenizerFast.from_pretrained(model_id, **kwargs)
         self.processor = get_deepseek_v4_tokenizer(base_tokenizer)
@@ -120,13 +127,70 @@ class DeepseekV4Template(Template):
         self.truncation_strategy = truncation_strategy
         self.default_system = default_system
         self._test_support_assistant_tokens_mask()
-        self.pre_pipeline = [
-            self._add_default_system,
-            self._to_standard_reasoning_content,
-            self._build_standard_messages,
+
+        self.pre_pipeline_names = [
+            '_add_default_system',
+            '_to_standard_reasoning_content',
+            '_build_standard_messages',
         ]
-        self.post_pipeline = [
-            self._check_max_length,
-            self._add_attention_fields,
-            self._roll_labels,
+        self.post_pipeline_names = [
+            '_check_max_length',
+            '_add_attention_fields',
+            '_roll_labels',
         ]
+
+    def parse(self, decoded: str) -> List[Dict[str, Any]]:
+        text = decoded or ''
+        if DeepseekV4Template._TOOL_CALLS_START not in text:
+            return []
+
+        parse_text = re.sub(
+            r'\s*' + re.escape(DeepseekV4Template._TOOL_CALLS_START),
+            '\n\n' + DeepseekV4Template._TOOL_CALLS_START,
+            text,
+            count=1,
+        )
+        if eos_token not in parse_text:
+            parse_text += eos_token
+
+        for thinking_mode in ('chat', 'thinking'):
+            try:
+                message = parse_message_from_completion_text(parse_text, thinking_mode=thinking_mode)
+            except ValueError:
+                continue
+            tool_calls = message.get('tool_calls', []) or []
+            for tool_call in tool_calls:
+                function = tool_call.get('function', {})
+                arguments = function.get('arguments')
+                if isinstance(arguments, str):
+                    try:
+                        function['arguments'] = json.loads(arguments) if arguments.strip() else {}
+                    except json.JSONDecodeError:
+                        function['arguments'] = {}
+            return tool_calls
+
+        return []
+
+    def clean(self, decoded: str) -> str:
+        text = decoded or ''
+        while True:
+            start = text.find(DeepseekV4Template._TOOL_CALLS_START)
+            if start < 0:
+                return text.rstrip()
+
+            end = text.find(
+                DeepseekV4Template._TOOL_CALLS_END,
+                start + len(DeepseekV4Template._TOOL_CALLS_START),
+            )
+            if end < 0:
+                text = text[:start]
+                continue
+
+            end += len(DeepseekV4Template._TOOL_CALLS_END)
+            text = text[:start] + text[end:]
+
+    def parse_tool_call(self, decoded: str) -> List[Dict[str, Any]]:
+        return self.parse(decoded)
+
+    def clean_tool_call(self, decoded: str) -> str:
+        return self.clean(decoded)

--- a/tests/template/test_deepseek_v4_tool_call.py
+++ b/tests/template/test_deepseek_v4_tool_call.py
@@ -1,0 +1,53 @@
+from twinkle.template.base import Template
+from twinkle.template.deepseek_v4 import DeepseekV4Template
+
+DSML_TOOL_CALL = ('Need data.\n\n'
+                  '<｜DSML｜tool_calls>\n'
+                  '<｜DSML｜invoke name="search">\n'
+                  '<｜DSML｜parameter name="q" string="true">weather</｜DSML｜parameter>\n'
+                  '<｜DSML｜parameter name="limit" string="false">3</｜DSML｜parameter>\n'
+                  '</｜DSML｜invoke>\n'
+                  '</｜DSML｜tool_calls>')
+
+
+def test_deepseek_v4_parse_and_clean_tool_call():
+    template = DeepseekV4Template.__new__(DeepseekV4Template)
+
+    calls = template.parse(DSML_TOOL_CALL)
+
+    assert calls == [{
+        'type': 'function',
+        'function': {
+            'name': 'search',
+            'arguments': {
+                'q': 'weather',
+                'limit': 3,
+            },
+        },
+    }]
+    assert template.clean(DSML_TOOL_CALL) == 'Need data.'
+    assert template.parse_tool_call(DSML_TOOL_CALL) == calls
+    assert template.clean_tool_call(DSML_TOOL_CALL) == 'Need data.'
+
+
+def test_deepseek_v4_parse_tool_call_normalizes_block_prefix_whitespace():
+    template = DeepseekV4Template.__new__(DeepseekV4Template)
+    expected_args = {'q': 'weather', 'limit': 3}
+
+    for separator in ('', '\n', '\n\n\n', '   '):
+        text = DSML_TOOL_CALL.replace('Need data.\n\n<｜DSML｜tool_calls>', f'Need data.{separator}<｜DSML｜tool_calls>')
+
+        calls = template.parse(text)
+
+        assert calls[0]['function']['name'] == 'search'
+        assert calls[0]['function']['arguments'] == expected_args
+
+
+def test_template_dispatches_deepseek_tool_call_parser():
+    template = Template.__new__(Template)
+    template.model_id = 'deepseek-v4'
+
+    calls = template.parse_tool_call(DSML_TOOL_CALL)
+
+    assert calls[0]['function']['name'] == 'search'
+    assert template.clean_tool_call(DSML_TOOL_CALL) == 'Need data.'


### PR DESCRIPTION
# PR type
- [x] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information

- Fix `DeepseekV4Template` initialization because the  [pr](https://github.com/modelscope/twinkle/pull/199/changes#diff-10f78be6fc808ec0b8f01190e4e968bc93614ad474ff358d36e029f846e58b76) and tool-call handling.

This PR updates `DeepseekV4Template` to initialize the template fields expected by the base `Template` pipeline, including `model_id`, `pre_pipeline_names`, and `post_pipeline_names`. This fixes the runtime error:


  File "/root/twinkle/src/twinkle/template/base.py", line 172, in _invoke_pre_pipeline
    for pipeline_name in self.pre_pipeline_names:
                         ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'DeepseekV4Template' object has no attribute 'pre_pipeline_names'