### PR TITLE
fix: remove overly restrictive Ray log rotation config

### DIFF
--- a/cookbook/client/server/megatron/run.sh
+++ b/cookbook/client/server/megatron/run.sh
@@ -57,10 +57,6 @@ DEFAULT_SERVER_CONFIG_FILE="/twinkle/cookbook/client/server/megatron/server_conf
 # --- Ray Prometheus 配置路径（Ray 自动生成，用于注入 LGTM） ---
 RAY_PROMETHEUS_CONFIG_SUFFIX="session_latest/metrics/prometheus/prometheus.yml"
 
-# --- Ray 日志轮转配置 ---
-export RAY_ROTATION_MAX_BYTES=1024
-export RAY_ROTATION_BACKUP_COUNT=1
-
 # ============================================
 # 参数解析（支持 --key=value 或 --key value 格式）
 # ============================================


### PR DESCRIPTION
## Summary
- Remove `RAY_ROTATION_MAX_BYTES=1024` and `RAY_ROTATION_BACKUP_COUNT=1` from the Megatron server startup script
- The 1KB log rotation limit was causing worker tracebacks to be truncated in production, making it impossible to diagnose the root cause of NCCL timeout crashes
- Ray defaults (50MB max, 5 backups) are appropriate for production workloads with long-running processes

## Background
During investigation of a production outage (NCCL collective timeout → SIGABRT on all 4 worker ranks), the only evidence of the original Python exception in `forward_backward` was a fragmented stack trace in the aggregated `run.log`. The individual `worker-*.err` files were empty or contained only the final NCCL abort message because 1KB rotation was discarding the full traceback before it could be captured.

## Test plan
- [ ] Deploy with the updated script and verify worker log files contain complete tracebacks under error conditions
- [ ] Confirm Ray log directory disk usage remains within acceptable bounds with default rotation settings