### PR TITLE
chore: apply release 0.4 delta to main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,25 @@
 # ---------- Stage 0: grab pre-built binaries ----------
 FROM redis:7.4.9 AS redis
 FROM grafana/otel-lgtm:0.28.0 AS lgtm
-FROM modelscope-registry.cn-hangzhou.cr.aliyuncs.com/modelscope-repo/modelscope:ubuntu22.04-cuda12.9.1-py312-torch2.10.0-vllm0.19.1-modelscope1.35.4-swift4.1.3
+FROM modelscope-registry.cn-hangzhou.cr.aliyuncs.com/modelscope-repo/modelscope:ubuntu22.04-cuda13.0.3-py312-torch2.11.0-vllm0.21.0-modelscope1.36.3-swift4.2.3
 
-# Forward-compat user-mode CUDA driver shim, then pip cuDNN ahead of apt cuDNN (transformer_engine undefined-symbol fix). Path must match base image's Python version.
-ENV LD_LIBRARY_PATH="/usr/local/cuda/compat:/usr/local/lib/python3.12/dist-packages/nvidia/cudnn/lib:${LD_LIBRARY_PATH}"
+# Put the real CUDA runtime ahead of package-private stubs, then keep the forward-compat
+# driver shim and pip cuDNN ahead of apt cuDNN.
+ENV LD_LIBRARY_PATH="/usr/local/cuda-13.0/targets/x86_64-linux/lib:/usr/local/cuda/lib64:/usr/local/lib/python3.12/site-packages/nvidia/cu13/lib:/usr/local/cuda/compat:/usr/local/lib/python3.12/dist-packages/nvidia/cudnn/lib:${LD_LIBRARY_PATH}"
 
 # Only twinkle-specific deps; everything else (torch, vllm, TE, flash-attn, megatron-core, mcore-bridge, transformers, peft, accelerate) ships in the base.
-RUN python --version && \
-    python -m pip --version && \
-    python -m pip install --no-cache-dir \
-        flash-linear-attention \
+RUN pip config set global.index-url https://mirrors.cloud.aliyuncs.com/pypi/simple && \
+    pip config set install.trusted-host mirrors.cloud.aliyuncs.com && \
+    pip install --no-cache-dir \
         tinker==0.16.1 \
         "ray[serve]" && \
+    pip install --no-cache-dir --no-deps \
+        flash-linear-attention \
+        apache-tvm-ffi==0.1.9 \
+        tilelang==0.1.9 && \
+    ln -sf /usr/local/cuda-13.0/targets/x86_64-linux/lib/libcudart.so \
+        /usr/local/lib/python3.12/site-packages/tilelang/lib/libcudart_stub.so && \
+    python -c "import ctypes, os; stub_path = '/usr/local/lib/python3.12/site-packages/tilelang/lib/libcudart_stub.so'; lib = ctypes.CDLL(stub_path); getattr(lib, 'cudaDeviceReset'); print(f'tilelang cudart path: {os.path.realpath(stub_path)}')" && \
     rm -rf /root/.cache /tmp/*
 
 # Clone and install twinkle, checkout to latest v-tag
@@ -24,7 +31,7 @@ RUN echo "Available release branches:" && git branch -r -l 'origin/release/*' --
     git checkout --track "$LATEST_RELEASE"
 
 # Install twinkle itself (with server extras: redis + otel + telemetry)
-RUN python -m pip install -e ".[server]" --no-build-isolation
+RUN pip install -e ".[server]" --no-build-isolation
 
 # ---------- Redis server ----------
 COPY --from=redis /usr/local/bin/redis-server /usr/local/bin/redis-server
@@ -34,5 +41,6 @@ COPY --from=redis /usr/local/bin/redis-cli /usr/local/bin/redis-cli
 COPY --from=lgtm /otel-lgtm /otel-lgtm
 COPY cookbook/observability/grafana/dashboards/twinkle-overview.json \
      /otel-lgtm/grafana/conf/provisioning/dashboards/twinkle-overview.json
+
 
 WORKDIR /twinkle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 # ---------- Stage 0: grab pre-built binaries ----------
-FROM redis:7 AS redis
-FROM grafana/otel-lgtm:latest AS lgtm
+FROM redis:7.4.9 AS redis
+FROM grafana/otel-lgtm:0.28.0 AS lgtm
 FROM modelscope-registry.cn-hangzhou.cr.aliyuncs.com/modelscope-repo/modelscope:ubuntu22.04-cuda12.9.1-py312-torch2.10.0-vllm0.19.1-modelscope1.35.4-swift4.1.3
 
 # Forward-compat user-mode CUDA driver shim, then pip cuDNN ahead of apt cuDNN (transformer_engine undefined-symbol fix). Path must match base image's Python version.
 ENV LD_LIBRARY_PATH="/usr/local/cuda/compat:/usr/local/lib/python3.12/dist-packages/nvidia/cudnn/lib:${LD_LIBRARY_PATH}"
 
 # Only twinkle-specific deps; everything else (torch, vllm, TE, flash-attn, megatron-core, mcore-bridge, transformers, peft, accelerate) ships in the base.
-RUN pip install --no-cache-dir \
+RUN python --version && \
+    python -m pip --version && \
+    python -m pip install --no-cache-dir \
         flash-linear-attention \
         tinker==0.16.1 \
         "ray[serve]" && \
@@ -22,7 +24,7 @@ RUN echo "Available release branches:" && git branch -r -l 'origin/release/*' --
     git checkout --track "$LATEST_RELEASE"
 
 # Install twinkle itself (with server extras: redis + otel + telemetry)
-RUN pip install -e ".[server]" --no-build-isolation
+RUN python -m pip install -e ".[server]" --no-build-isolation
 
 # ---------- Redis server ----------
 COPY --from=redis /usr/local/bin/redis-server /usr/local/bin/redis-server
@@ -32,6 +34,5 @@ COPY --from=redis /usr/local/bin/redis-cli /usr/local/bin/redis-cli
 COPY --from=lgtm /otel-lgtm /otel-lgtm
 COPY cookbook/observability/grafana/dashboards/twinkle-overview.json \
      /otel-lgtm/grafana/conf/provisioning/dashboards/twinkle-overview.json
-
 
 WORKDIR /twinkle

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,3 @@ COPY --from=redis /usr/local/bin/redis-cli /usr/local/bin/redis-cli
 COPY --from=lgtm /otel-lgtm /otel-lgtm
 COPY cookbook/observability/grafana/dashboards/twinkle-overview.json \
      /otel-lgtm/grafana/conf/provisioning/dashboards/twinkle-overview.json
-
-
-WORKDIR /twinkle

--- a/cookbook/client/server/megatron/run.sh
+++ b/cookbook/client/server/megatron/run.sh
@@ -331,7 +331,7 @@ if pgrep -f "twinkle.server" > /dev/null 2>&1; then
 fi
 if pgrep -if "vLLM" > /dev/null 2>&1; then
     print_warning "vLLM 进程未退出，强制终止..."
-    pkill -9if "vLLM" 2>/dev/null || true
+    pkill -9 -i -f "vLLM" 2>/dev/null || true
 fi
 
 print_info "停止已有的 Ray 集群..."

--- a/cookbook/client/server/megatron/run.sh
+++ b/cookbook/client/server/megatron/run.sh
@@ -51,11 +51,19 @@ RAY_ADDRESS="127.0.0.1:$RAY_PORT"
 # --- 路径配置 ---
 DEFAULT_TEMP_DIR="/dashscope/caches/application/ray_logs"
 LOG_FILE="run.log"
+REDIS_LOG_FILE="/twinkle/redis.log"
 DEFAULT_SAVE_DIR="/dashscope/caches/application/save"
 DEFAULT_SERVER_CONFIG_FILE="/twinkle/cookbook/client/server/megatron/server_config.yaml"
 
-# --- Ray Prometheus 配置路径（Ray 自动生成，用于注入 LGTM） ---
-RAY_PROMETHEUS_CONFIG_SUFFIX="session_latest/metrics/prometheus/prometheus.yml"
+# --- LGTM 版本配置（与 grafana/otel-lgtm:0.28.0 保持一致） ---
+LGTM_VERSION="${LGTM_VERSION:-0.28.0}"
+GRAFANA_VERSION="${GRAFANA_VERSION:-v13.0.1}"
+PROMETHEUS_VERSION="${PROMETHEUS_VERSION:-v3.11.3}"
+TEMPO_VERSION="${TEMPO_VERSION:-v2.10.5}"
+LOKI_VERSION="${LOKI_VERSION:-v3.7.1}"
+PYROSCOPE_VERSION="${PYROSCOPE_VERSION:-v2.0.2}"
+OPENTELEMETRY_COLLECTOR_VERSION="${OPENTELEMETRY_COLLECTOR_VERSION:-v0.151.0}"
+OBI_VERSION="${OBI_VERSION:-v0.9.0}"
 
 # ============================================
 # 参数解析（支持 --key=value 或 --key value 格式）
@@ -158,8 +166,6 @@ else
     IFS=';' read -ra GPU_WORKERS <<< "$GPU_WORKERS_INPUT"
 fi
 
-RAY_PROMETHEUS_CONFIG="${TEMP_DIR}/${RAY_PROMETHEUS_CONFIG_SUFFIX}"
-
 # ============================================
 # 辅助函数
 # ============================================
@@ -188,6 +194,53 @@ print_header() {
     print_separator
     echo -e "\033[1;34m $1 \033[0m"
     print_separator
+}
+
+wait_for_redis_ready() {
+    local timeout="${1:-30}"
+
+    for ((i=1; i<=timeout; i++)); do
+        if redis-cli -p 6380 ping 2>/dev/null | grep -q '^PONG$'; then
+            return 0
+        fi
+        sleep 1
+    done
+
+    return 1
+}
+
+wait_for_redis_stopped() {
+    local timeout="${1:-30}"
+
+    for ((i=1; i<=timeout; i++)); do
+        if command -v ss &> /dev/null; then
+            if ! ss -lnt 2>/dev/null | grep -q ':6380 '; then
+                return 0
+            fi
+        elif ! redis-cli -p 6380 ping 2>/dev/null | grep -q '^PONG$'; then
+            return 0
+        fi
+        sleep 1
+    done
+
+    return 1
+}
+
+wait_for_lgtm_ready() {
+    local lgtm_pid="$1"
+    local timeout="${2:-90}"
+
+    for ((i=1; i<=timeout; i++)); do
+        if [ -f /tmp/ready ]; then
+            return 0
+        fi
+        if ! kill -0 "$lgtm_pid" 2>/dev/null; then
+            return 1
+        fi
+        sleep 1
+    done
+
+    return 1
 }
 
 # 解析节点配置 "devices" -> 返回 devices 和自动计算 _gpu_count
@@ -285,7 +338,18 @@ print_info "停止已有的 Ray 集群..."
 ray stop --force 2>/dev/null || true
 
 print_info "停止已有的 Redis..."
-pkill redis-server 2>/dev/null || true
+redis-cli -p 6380 shutdown nosave 2>/dev/null || pkill redis-server 2>/dev/null || true
+if ! wait_for_redis_stopped 30; then
+    print_warning "Redis 未在 30 秒内退出，强制终止..."
+    pkill -9 redis-server 2>/dev/null || true
+    if ! wait_for_redis_stopped 10; then
+        print_error "Redis 端口 6380 未释放"
+        if command -v ss &> /dev/null; then
+            ss -lntp 2>/dev/null | grep ':6380 ' || true
+        fi
+        exit 1
+    fi
+fi
 
 print_info "停止已有的 LGTM 观测栈..."
 pkill -f "/otel-lgtm/run-all.sh" 2>/dev/null || true
@@ -303,10 +367,19 @@ print_header "启动 Redis"
 
 if command -v redis-server &> /dev/null; then
     print_info "启动 Redis..."
-    redis-server --daemonize yes --port 6380 --save "" --appendonly no
-    print_success "Redis 已启动 (port 6380)"
+    redis-server --daemonize yes --port 6380 --save "" --appendonly no --logfile "$REDIS_LOG_FILE"
+    if wait_for_redis_ready 30; then
+        print_success "Redis 已启动 (port 6380)"
+    else
+        print_error "Redis 未能在 30 秒内启动或响应 PING (port 6380)"
+        if [ -f "$REDIS_LOG_FILE" ]; then
+            tail -n 50 "$REDIS_LOG_FILE"
+        fi
+        exit 1
+    fi
 else
-    print_warning "未检测到 redis-server，跳过"
+    print_error "未检测到 redis-server，但 server_config.yaml 使用 redis persistence"
+    exit 1
 fi
 
 # ============================================
@@ -372,28 +445,27 @@ ray status 2>/dev/null || true
 print_header "启动 LGTM 观测栈（可选）"
 
 if [ -d "/otel-lgtm" ]; then
-    # 等待 Ray 生成 Prometheus scrape 配置
-    sleep 2
-
-    # 还原原始配置（防止重复执行时累积追加）再注入 Ray scrape 配置
-    [ -f /otel-lgtm/prometheus.yaml.orig ] || cp /otel-lgtm/prometheus.yaml /otel-lgtm/prometheus.yaml.orig
-    cp /otel-lgtm/prometheus.yaml.orig /otel-lgtm/prometheus.yaml
-
-    if [ -f "$RAY_PROMETHEUS_CONFIG" ]; then
-        print_info "注入 Ray metrics scrape 配置到 LGTM Prometheus..."
-        cat "$RAY_PROMETHEUS_CONFIG" >> /otel-lgtm/prometheus.yaml
-    else
-        print_warning "Ray Prometheus 配置未生成，跳过 scrape 注入"
-        echo "  - 预期路径: $RAY_PROMETHEUS_CONFIG"
+    if [ -f /otel-lgtm/prometheus.yaml.orig ]; then
+        cp /otel-lgtm/prometheus.yaml.orig /otel-lgtm/prometheus.yaml
     fi
 
     print_info "启动 LGTM 观测栈..."
-    (cd /otel-lgtm && nohup ./run-all.sh > /twinkle/lgtm.log 2>&1 &)
-    print_success "LGTM 观测栈已启动"
-    echo "  - Grafana:   http://localhost:3000 (admin/admin)"
-    echo "  - OTLP gRPC: localhost:4317"
-    echo "  - OTLP HTTP: localhost:4318"
-    echo "  - 日志文件:  /twinkle/lgtm.log"
+    rm -f /tmp/ready
+    export LGTM_VERSION GRAFANA_VERSION PROMETHEUS_VERSION TEMPO_VERSION LOKI_VERSION
+    export PYROSCOPE_VERSION OPENTELEMETRY_COLLECTOR_VERSION OBI_VERSION
+    (cd /otel-lgtm && exec nohup ./run-all.sh > /twinkle/lgtm.log 2>&1) &
+    LGTM_PID=$!
+
+    if wait_for_lgtm_ready "$LGTM_PID" 120; then
+        print_success "LGTM 观测栈已启动"
+        echo "  - Grafana:   http://localhost:3000 (admin/admin)"
+        echo "  - OTLP gRPC: localhost:4317"
+        echo "  - OTLP HTTP: localhost:4318"
+        echo "  - 日志文件:  /twinkle/lgtm.log"
+    else
+        print_warning "LGTM 观测栈未在 120 秒内就绪，Twinkle 将继续启动"
+        echo "  - 日志文件: /twinkle/lgtm.log"
+    fi
 else
     print_warning "未检测到 LGTM 观测栈 (/otel-lgtm)，跳过"
 fi
@@ -408,7 +480,7 @@ echo ""
 
 # 启动服务器并实时显示日志
 touch "$LOG_FILE"  # 预创建文件，避免 tail -f 在文件尚未写入时报错
-nohup python -m twinkle.server --config "$SERVER_CONFIG_FILE" > "$LOG_FILE" 2>&1 &
+nohup python -m twinkle.server launch --config "$SERVER_CONFIG_FILE" > "$LOG_FILE" 2>&1 &
 SERVER_PID=$!
 print_success "Twinkle Server 已启动 (PID: $SERVER_PID)"
 

--- a/cookbook/client/server/megatron/run.sh
+++ b/cookbook/client/server/megatron/run.sh
@@ -365,7 +365,7 @@ pkill pyroscope 2>/dev/null || true
 # ============================================
 print_header "启动 Redis"
 
-if command -v redis-server &> /dev/null; then
+if command -v redis-server &> /dev/null && command -v redis-cli &> /dev/null; then
     print_info "启动 Redis..."
     redis-server --daemonize yes --port 6380 --save "" --appendonly no --logfile "$REDIS_LOG_FILE"
     if wait_for_redis_ready 30; then
@@ -378,7 +378,7 @@ if command -v redis-server &> /dev/null; then
         exit 1
     fi
 else
-    print_error "未检测到 redis-server，但 server_config.yaml 使用 redis persistence"
+    print_error "未检测到 redis-server 或 redis-cli，但 server_config.yaml 使用 redis persistence"
     exit 1
 fi
 

--- a/cookbook/client/server/megatron/server_config.yaml
+++ b/cookbook/client/server/megatron/server_config.yaml
@@ -58,7 +58,7 @@ applications:
   # 3. Sampler Service - Runs inference / sampling using vLLM engine
   #    Used for generating text from the model (e.g., evaluating LoRA results).
   #    Config: TP=2 x DP=2 on 4 GPUs, ~27GB weights/GPU, ~37GB for KV cache + LoRA
-  - name: sampler-Qwen3.6-35B-A3B
+  - name: sampler-Qwen3.6-27B
     route_prefix: /api/v1/sampler/Qwen/Qwen3.6-27B
     import_path: sampler
     args:
@@ -100,7 +100,7 @@ applications:
 
   # 2. Model Service - Hosts the base model for training.
   #    Config: PP=2 x DP=2 on 4 GPUs, ~27GB weights/GPU, comfortable for LoRA training
-  - name: models-Qwen3.6-35B-A3B
+  - name: models-Qwen3.6-27B
     route_prefix: /api/v1/model/Qwen/Qwen3.6-27B
     import_path: model
     args:

--- a/cookbook/client/server/megatron/server_config.yaml
+++ b/cookbook/client/server/megatron/server_config.yaml
@@ -38,6 +38,8 @@ applications:
     args:
       server_config:
         per_token_model_limit: 3      # Maximum number of models (adapters) per token (server-globally enforced)
+      supported_models:
+        - Qwen/Qwen3.6-27B
 
     deployments:
       - name: TinkerCompatServer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ megatron = ["megatron-core>=0.12.0", "transformer-engine[pytorch]", "mcore_bridg
 vllm = ["vllm>=0.11"]
 ray = ["ray[serve]"]
 datajuicer = ["py-data-juicer"]
-tinker = ["tinker==0.14.0"]
+tinker = ["tinker==0.16.1"]
 test = ["hypothesis>=6.0", "pytest", "pytest-asyncio"]
 server = [
   "redis>=5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ transformers = [
   "torchvision",
 ]
 kernels = ["kernels"]
-megatron = ["megatron-core>=0.12.0", "transformer-engine[pytorch]", "mcore_bridge", "ms-swift==4.1.3"]
+megatron = ["megatron-core>=0.12.0", "transformer-engine[pytorch]", "mcore_bridge"]
 vllm = ["vllm>=0.11"]
 ray = ["ray[serve]"]
 datajuicer = ["py-data-juicer"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
   "peft>=0.11.0,<=0.19.0",
   "transformers",
   "typer>=0.9.0",
-  "pyzmq",
 ]
 
 [project.scripts]
@@ -28,12 +27,11 @@ transformers = [
   "torchvision",
 ]
 kernels = ["kernels"]
-megatron = ["megatron-core>=0.12.0", "transformer-engine[pytorch]", "mcore_bridge"]
+megatron = ["megatron-core>=0.12.0", "transformer-engine[pytorch]", "mcore_bridge", "ms-swift==4.1.3"]
 vllm = ["vllm>=0.11"]
 ray = ["ray[serve]"]
-datajuicer = ["py-data-juicer"]
 tinker = ["tinker==0.16.1"]
-test = ["hypothesis>=6.0", "pytest", "pytest-asyncio"]
+test = ["hypothesis>=6.0"]
 server = [
   "redis>=5.0",
   "psutil>=5.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "twinkle-kit"
-version = "0.4.0.dev0"
+version = "0.4.0"
 description = "Training API for large language models with efficient data handling and advanced optimization techniques."
 readme = "README.md"
 authors = [{ name = "ModelScope", email = "contact@modelscope.cn" }]
@@ -32,7 +32,7 @@ megatron = ["megatron-core>=0.12.0", "transformer-engine[pytorch]", "mcore_bridg
 vllm = ["vllm>=0.11"]
 ray = ["ray[serve]"]
 datajuicer = ["py-data-juicer"]
-tinker = ["tinker==0.14.0"]
+tinker = ["tinker==0.16.1"]
 test = ["hypothesis>=6.0", "pytest", "pytest-asyncio"]
 server = [
   "redis>=5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "twinkle-kit"
-version = "0.4.0"
+version = "0.4.0.dev0"
 description = "Training API for large language models with efficient data handling and advanced optimization techniques."
 readme = "README.md"
 authors = [{ name = "ModelScope", email = "contact@modelscope.cn" }]
@@ -15,6 +15,7 @@ dependencies = [
   "peft>=0.11.0,<=0.19.0",
   "transformers",
   "typer>=0.9.0",
+  "pyzmq",
 ]
 
 [project.scripts]
@@ -30,8 +31,9 @@ kernels = ["kernels"]
 megatron = ["megatron-core>=0.12.0", "transformer-engine[pytorch]", "mcore_bridge", "ms-swift==4.1.3"]
 vllm = ["vllm>=0.11"]
 ray = ["ray[serve]"]
-tinker = ["tinker==0.16.1"]
-test = ["hypothesis>=6.0"]
+datajuicer = ["py-data-juicer"]
+tinker = ["tinker==0.14.0"]
+test = ["hypothesis>=6.0", "pytest", "pytest-asyncio"]
 server = [
   "redis>=5.0",
   "psutil>=5.9.0",

--- a/src/twinkle/model/megatron/megatron.py
+++ b/src/twinkle/model/megatron/megatron.py
@@ -600,7 +600,9 @@ class MegatronModel(TwinkleModel, nn.Module, CheckpointEngineMixin):
 
         success, grad_norm, num_zeros = optimizer.step()
         # Store grad_norm for later retrieval
-        optimizer_config._last_grad_norm = grad_norm.detach().cpu().item() if grad_norm is not None else 0.0
+        if grad_norm is not None:
+            grad_norm = grad_norm.item() if hasattr(grad_norm, 'item') else grad_norm
+        optimizer_config._last_grad_norm = float(grad_norm) if grad_norm is not None else 0.0
         optimizer_config._last_step_success = success
 
     def _is_model_ddp_wrapped(self) -> bool:

--- a/src/twinkle/server/common/datum.py
+++ b/src/twinkle/server/common/datum.py
@@ -82,7 +82,9 @@ def extract_rl_features_for_loss(datum: types.Datum | list[types.Datum]) -> dict
     if advantages:
         result['advantages'] = advantages
     if ref_logps_lists:
-        result['ref_outputs'] = {'logps': torch.stack([torch.tensor(r, dtype=torch.float32) for r in ref_logps_lists])}
+        from twinkle.utils import pad_and_stack_tensors
+        ref_logps_tensors = [torch.tensor(r, dtype=torch.float32) for r in ref_logps_lists]
+        result['ref_outputs'] = {'logps': pad_and_stack_tensors(ref_logps_tensors, pad_value=0.0, concat=False)}
     return result
 
 

--- a/src/twinkle/server/model/backends/common.py
+++ b/src/twinkle/server/model/backends/common.py
@@ -176,16 +176,24 @@ class TwinkleCompatModelBase:
 
     def _tinker_build_output(self, inputs, outputs, return_full_logprobs: bool = False):
         """Extract logits/logps from model outputs and build per-datum output list."""
-        logits = self._tensor_output_to_rows(outputs.get('logits'))
-        logps = self._tensor_output_to_rows(outputs.get('logps'))
+        seq_lens = [feature.loss_fn_inputs['target_tokens'].to_torch().long().view(-1).numel() for feature in inputs]
+        logits = self._tensor_output_to_rows(outputs.get('logits'), seq_lens, kind='logits')
+        logps = self._tensor_output_to_rows(outputs.get('logps'), seq_lens, kind='logps')
         if logits is None and logps is None:
             # non-last PP stage: no outputs produced, collector will discard this
             return []
         return self._get_forward_output(inputs, logits, logps, return_full_logprobs=return_full_logprobs)
 
     @staticmethod
-    def _tensor_output_to_rows(value):
-        """Expand tensor or microbatch tensor-list outputs into one row per input sample."""
+    def _tensor_output_to_rows(value, seq_lens: list[int], *, kind: str) -> list[torch.Tensor] | None:
+        """Normalize backend tensors to one row per Tinker datum.
+
+        Accepted backend shapes:
+        - per-datum lists: ``[[T], [T]]`` for logps, ``[[T, V], [T, V]]`` for logits.
+        - batch-major tensors: ``[B, T]`` for logps, ``[B, T, V]`` for logits.
+        - packed tensors: ``[sum(T)]`` for logps, ``[sum(T), V]`` for logits.
+        - Megatron wrappers: an extra leading singleton dimension around any of the above.
+        """
         if value is None:
             return None
 
@@ -198,14 +206,79 @@ class TwinkleCompatModelBase:
         elif not (isinstance(value, list) and all(isinstance(item, torch.Tensor) for item in value)):
             tensors = [torch.as_tensor(value, dtype=torch.float32)]
 
+        tensors = [tensor.detach().cpu() for tensor in tensors]
+        if len(tensors) == len(seq_lens) and all(tensor.dim() <= 1 or tensor.shape[0] == 1 for tensor in tensors):
+            return [TwinkleCompatModelBase._normalize_single_row_tensor(tensor, kind=kind) for tensor in tensors]
+
         rows = []
         for tensor in tensors:
-            tensor = tensor.detach().cpu()
-            if tensor.dim() <= 1:
-                rows.append(tensor)
-            else:
-                rows.extend(tensor.unbind(0))
+            chunk_rows = TwinkleCompatModelBase._tensor_chunk_to_rows(tensor, seq_lens[len(rows):], kind=kind)
+            rows.extend(chunk_rows)
         return rows
+
+    @staticmethod
+    def _normalize_single_row_tensor(tensor: torch.Tensor, *, kind: str) -> torch.Tensor:
+        if kind == 'logits':
+            if tensor.dim() >= 3 and tensor.shape[0] == 1:
+                return tensor.squeeze(0)
+            return tensor
+
+        while tensor.dim() > 1 and tensor.shape[0] == 1:
+            tensor = tensor.squeeze(0)
+        return tensor
+
+    @staticmethod
+    def _split_packed_tensor(tensor: torch.Tensor, seq_lens: list[int]) -> list[torch.Tensor] | None:
+        if tensor.dim() == 0 or not seq_lens:
+            return None
+        split_rows = []
+        offset = 0
+        for seq_len in seq_lens:
+            if offset + seq_len > tensor.shape[0]:
+                break
+            split_rows.append(tensor[offset:offset + seq_len])
+            offset += seq_len
+            if offset == tensor.shape[0]:
+                break
+        return split_rows or None
+
+    @staticmethod
+    def _tensor_chunk_to_rows(tensor: torch.Tensor, seq_lens: list[int], *, kind: str) -> list[torch.Tensor]:
+        if tensor.dim() == 0 or len(seq_lens) <= 1:
+            return [TwinkleCompatModelBase._normalize_single_row_tensor(tensor, kind=kind)]
+
+        if kind == 'logps':
+            while tensor.dim() > 1 and tensor.shape[0] == 1:
+                tensor = tensor.squeeze(0)
+            if tensor.dim() >= 2:
+                batch_size = tensor.shape[0]
+                if batch_size <= len(seq_lens) and tensor.shape[1] >= max(seq_lens[:batch_size]):
+                    return [
+                        TwinkleCompatModelBase._normalize_single_row_tensor(row, kind=kind) for row in tensor.unbind(0)
+                    ]
+            packed_rows = TwinkleCompatModelBase._split_packed_tensor(tensor, seq_lens)
+            if packed_rows is not None:
+                return packed_rows
+            return [tensor]
+
+        if kind == 'logits':
+            if tensor.dim() >= 3 and tensor.shape[0] == 1:
+                packed_rows = TwinkleCompatModelBase._split_packed_tensor(tensor.squeeze(0), seq_lens)
+                if packed_rows is not None:
+                    return packed_rows
+                tensor = tensor.squeeze(0)
+            if tensor.dim() >= 3:
+                batch_size = tensor.shape[0]
+                if batch_size <= len(seq_lens) and tensor.shape[1] >= max(seq_lens[:batch_size]):
+                    return [
+                        TwinkleCompatModelBase._normalize_single_row_tensor(row, kind=kind) for row in tensor.unbind(0)
+                    ]
+            packed_rows = TwinkleCompatModelBase._split_packed_tensor(tensor, seq_lens)
+            if packed_rows is not None:
+                return packed_rows
+            return [tensor]
+
+        raise ValueError(f'Unsupported tensor output kind: {kind}')
 
     @staticmethod
     def _get_forward_output(inputs: list[types.Datum],

--- a/src/twinkle/server/model/backends/common.py
+++ b/src/twinkle/server/model/backends/common.py
@@ -176,45 +176,41 @@ class TwinkleCompatModelBase:
 
     def _tinker_build_output(self, inputs, outputs, return_full_logprobs: bool = False):
         """Extract logits/logps from model outputs and build per-datum output list."""
-        logits = self._normalize_tensor_output(outputs.get('logits'))
-        logps = self._normalize_tensor_output(outputs.get('logps'))
+        logits = self._tensor_output_to_rows(outputs.get('logits'))
+        logps = self._tensor_output_to_rows(outputs.get('logps'))
         if logits is None and logps is None:
             # non-last PP stage: no outputs produced, collector will discard this
             return []
         return self._get_forward_output(inputs, logits, logps, return_full_logprobs=return_full_logprobs)
 
     @staticmethod
-    def _normalize_tensor_output(value):
-        """Normalize various output formats (tensor, list of tensors, nested lists, floats) to a single tensor.
-
-        Handles:
-        - None or empty list: returns None
-        - torch.Tensor: detach and move to cpu
-        - list of torch.Tensor: cat along dim=0
-        - list of floats/int: convert to tensor
-        """
+    def _tensor_output_to_rows(value):
+        """Expand tensor or microbatch tensor-list outputs into one row per input sample."""
         if value is None:
             return None
 
+        tensors = value
         if isinstance(value, torch.Tensor):
-            return value.detach().cpu()
+            tensors = [value]
+        elif isinstance(value, list) and not value:
+            # Non-last PP stages can legitimately produce no logits/logps.
+            return None
+        elif not (isinstance(value, list) and all(isinstance(item, torch.Tensor) for item in value)):
+            tensors = [torch.as_tensor(value, dtype=torch.float32)]
 
-        if isinstance(value, list):
-            if not value:  # empty list (e.g. non-last PP stage): treat as missing
-                return None
-            if isinstance(value[0], torch.Tensor):
-                return torch.cat(value, dim=0).detach().cpu()
-            return torch.as_tensor(value, dtype=torch.float32).detach().cpu()
-
-        if isinstance(value, (int, float)):
-            return torch.tensor([value], dtype=torch.float32)
-
-        raise ValueError(f'Unexpected type for tensor output: {type(value)}')
+        rows = []
+        for tensor in tensors:
+            tensor = tensor.detach().cpu()
+            if tensor.dim() <= 1:
+                rows.append(tensor)
+            else:
+                rows.extend(tensor.unbind(0))
+        return rows
 
     @staticmethod
     def _get_forward_output(inputs: list[types.Datum],
-                            logits: torch.Tensor,
-                            logps: torch.Tensor,
+                            logits: list[torch.Tensor] | None,
+                            logps: list[torch.Tensor] | None,
                             return_full_logprobs: bool = False) -> list[dict]:
         """Convert raw logits to the expected output format with logprobs and elementwise_loss.
 
@@ -226,24 +222,30 @@ class TwinkleCompatModelBase:
         elementwise_loss is always computed on the original (unpadded) length because the
         per-datum weights tensor has that length.
         """
-        from twinkle.utils.torch_utils import selective_log_softmax
         if logps is not None:
-            device = logps.device
+            if len(logps) != len(inputs):
+                raise ValueError(f'Expected {len(inputs)} logps rows, got {len(logps)}')
+            device = logps[0].device
         elif logits is not None:
-            device = logits.device
+            if len(logits) != len(inputs):
+                raise ValueError(f'Expected {len(inputs)} logits rows, got {len(logits)}')
+            device = logits[0].device
         else:
             raise ValueError('At least one of logits or logps must be provided.')
         results = []
         if logits is None:
             logits = [None] * len(inputs)
-        for idx, (feature, logit) in enumerate(zip(inputs, logits)):
+        if logps is None:
+            logps = [None] * len(inputs)
+        for feature, logit, feature_logps in zip(inputs, logits, logps):
             labels = feature.loss_fn_inputs['target_tokens'].to_torch().long().view(-1).to(device)
             weights = feature.loss_fn_inputs['weights'].to_torch().view(-1).to(device)
 
             seq_len = labels.numel()  # original unpadded length
 
-            if logps is None:
+            if feature_logps is None:
                 assert logit is not None, 'logit must not be None when logps is None'
+                from twinkle.utils.torch_utils import selective_log_softmax
                 feature_logits = logit[:seq_len, :]
                 token_log_probs_orig = selective_log_softmax(feature_logits, labels)
                 if return_full_logprobs:
@@ -258,10 +260,11 @@ class TwinkleCompatModelBase:
                 else:
                     token_log_probs_full = token_log_probs_orig
             else:
-                token_log_probs_orig = logps[idx, :seq_len]
+                feature_logps = feature_logps.to(device)
+                token_log_probs_orig = feature_logps[:seq_len]
                 # When return_full_logprobs is True, retain the full TP/CP-padded slice.
                 # Positions beyond seq_len have label -100 and are masked by _compute_sequence_logps.
-                token_log_probs_full = logps[idx] if return_full_logprobs else token_log_probs_orig
+                token_log_probs_full = feature_logps if return_full_logprobs else token_log_probs_orig
 
             # elementwise_loss: positive NLL loss (0.0 where masked)
             token_log_probs_orig = token_log_probs_orig.to(weights.device)

--- a/src/twinkle/server/model/backends/mock_model.py
+++ b/src/twinkle/server/model/backends/mock_model.py
@@ -16,7 +16,7 @@ import numpy as np
 import os
 from typing import Any
 
-from twinkle import remote_class
+from twinkle import remote_class, remote_function
 from twinkle.utils.logger import get_logger
 from twinkle.utils.seed import stable_seed
 
@@ -72,24 +72,30 @@ class TwinkleCompatMockModel:
             })
         return out
 
+    @remote_function()
     def tinker_forward_only(self, *, inputs: Any, adapter_name: str | None = None, **kwargs: Any) -> list[Any]:
         return [_to_tinker_loss_outputs(self._build_forward_result(inputs, adapter_name)), 0.0]
 
+    @remote_function()
     def tinker_forward_backward(self, *, inputs: Any, adapter_name: str, loss_fn: str, **kwargs: Any) -> list[Any]:
         loss_seed = stable_seed(self.model_id, adapter_name, self._rng_seed, 'loss', loss_fn)
         loss = float(np.random.default_rng(loss_seed).uniform(0.0, 1.0))
         return [_to_tinker_loss_outputs(self._build_forward_result(inputs, adapter_name, loss_value=loss)), loss]
 
+    @remote_function()
     def forward(self, *, inputs: Any, **kwargs: Any) -> list[dict[str, Any]]:
         return self._build_forward_result(inputs, kwargs.get('adapter_name'))
 
+    @remote_function()
     def forward_only(self, *, inputs: Any, **kwargs: Any) -> list[dict[str, Any]]:
         return self._build_forward_result(inputs, kwargs.get('adapter_name'))
 
+    @remote_function()
     def forward_backward(self, *, inputs: Any, **kwargs: Any) -> list[Any]:
         loss = float(np.random.default_rng(self._rng_seed).uniform(0.0, 1.0))
         return [self._build_forward_result(inputs, kwargs.get('adapter_name'), loss_value=loss), loss]
 
+    @remote_function()
     def calculate_loss(self, *, inputs: Any = None, **kwargs: Any) -> float:
         # Handler at twinkle_handlers.py:150 invokes with only ``adapter_name``;
         # the real backend keeps loss state on ``self`` so ``inputs`` is optional.
@@ -97,61 +103,79 @@ class TwinkleCompatMockModel:
 
     # ----- Backward / optimizer ------------------------------------------ #
 
+    @remote_function()
     def backward(self, *args: Any, **kwargs: Any) -> None:
         return None
 
+    @remote_function()
     def step(self, *args: Any, **kwargs: Any) -> None:
         return None
 
+    @remote_function()
     def zero_grad(self, *args: Any, **kwargs: Any) -> None:
         return None
 
+    @remote_function()
     def lr_step(self, *args: Any, **kwargs: Any) -> None:
         return None
 
+    @remote_function()
     def clip_grad_norm(self, *args: Any, **kwargs: Any) -> float:
         return 0.0
 
+    @remote_function()
     def clip_grad_and_step(self, *args: Any, **kwargs: Any) -> None:
         return None
 
+    @remote_function()
     def tinker_step(self, *, adam_params: Any = None, **kwargs: Any) -> None:
         return None
 
+    @remote_function()
     def tinker_calculate_metric(self, is_training: bool, **kwargs: Any) -> dict[str, float]:
         return {'loss': 0.5, 'grad_norm': 0.1}
 
+    @remote_function()
     def calculate_metric(self, *args: Any, **kwargs: Any) -> dict[str, float]:
         return {'loss': 0.5, 'grad_norm': 0.1}
 
+    @remote_function()
     def tinker_load(self, checkpoint_dir: str, **kwargs: Any) -> None:
         return None
 
     # ----- Configuration setters ----------------------------------------- #
 
+    @remote_function()
     def set_loss(self, *args: Any, **kwargs: Any) -> None:
         return None
 
+    @remote_function()
     def set_optimizer(self, *args: Any, **kwargs: Any) -> None:
         return None
 
+    @remote_function()
     def set_lr_scheduler(self, *args: Any, **kwargs: Any) -> None:
         return None
 
+    @remote_function()
     def set_template(self, *args: Any, **kwargs: Any) -> None:
         return None
 
+    @remote_function()
     def set_processor(self, *args: Any, **kwargs: Any) -> None:
         return None
 
+    @remote_function()
     def add_metric(self, *args: Any, **kwargs: Any) -> None:
         return None
 
+    @remote_function()
     def apply_patch(self, *args: Any, **kwargs: Any) -> None:
         return None
 
     # ----- Persistence stubs --------------------------------------------- #
 
+    @remote_function()
     def save(self, name: str = 'latest', output_dir: str | None = None, **kwargs: Any) -> str:
         """Materialize an empty checkpoint dir so downstream existence checks pass.
 
@@ -164,41 +188,50 @@ class TwinkleCompatMockModel:
         os.makedirs(target, exist_ok=True)
         return target
 
+    @remote_function()
     def load(self, *args: Any, **kwargs: Any) -> None:
         return None
 
+    @remote_function()
     def resume_from_checkpoint(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
         return {'status': 'ok', 'progress': {}}
 
+    @remote_function()
     def get_state_dict(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
         return {}
 
+    @remote_function()
     def get_train_configs(self, *args: Any, **kwargs: Any) -> str:
         # Real backend returns a JSON-serialized config string; handler wraps it
         # into ``GetTrainConfigsResponse.result: str`` (types/model.py:213).
         return '{}'
 
+    @remote_function()
     def upload_to_hub(self, *args: Any, **kwargs: Any) -> None:
         return None
 
     # ----- Adapter management -------------------------------------------- #
 
+    @remote_function()
     def add_adapter(self, adapter_name: str, **cfg: Any) -> None:
         """Record an adapter without loading real weights."""
         self._adapters[adapter_name] = dict(cfg)
 
+    @remote_function()
     def add_adapter_to_model(self, adapter_name: str, config: Any = None, **cfg: Any) -> None:
         merged: dict[str, Any] = dict(cfg)
         if config is not None:
             merged.setdefault('config', config)
         self._adapters[adapter_name] = merged
 
+    @remote_function()
     def remove_adapter(self, adapter_name: str) -> None:
         """Remove ``adapter_name``; raise ``KeyError`` if it was never added."""
         if adapter_name not in self._adapters:
             raise KeyError(f'adapter not present: {adapter_name}')
         del self._adapters[adapter_name]
 
+    @remote_function()
     def has_adapter(self, adapter_name: str) -> bool:
         return adapter_name in self._adapters
 

--- a/src/twinkle/server/model/tinker_handlers.py
+++ b/src/twinkle/server/model/tinker_handlers.py
@@ -179,6 +179,7 @@ def _register_tinker_routes(app: FastAPI, self_fn: Callable[[], ModelManagement]
         datum_list = body.forward_backward_input.data
         input_tokens = sum(len(d.model_input.to_ints()) for d in datum_list)
         batch_size = len(datum_list)
+        loss_fn = body.forward_backward_input.loss_fn
         return await self.schedule_task(
             _do_forward_backward,
             model_id=body.model_id,
@@ -186,6 +187,7 @@ def _register_tinker_routes(app: FastAPI, self_fn: Callable[[], ModelManagement]
             input_tokens=input_tokens,
             batch_size=batch_size,
             data_world_size=self.data_world_size,
+            batch_size_multiple=2 if loss_fn == 'importance_sampling' else None,
             task_type='forward_backward',
         )
 

--- a/src/twinkle/server/model/twinkle_handlers.py
+++ b/src/twinkle/server/model/twinkle_handlers.py
@@ -48,10 +48,11 @@ def _parse_inputs(inputs: Any):
 
 
 def _get_twinkle_adapter_name(request: Request, adapter_name: str | None) -> str | None:
-    """Build the per-request adapter name from the request_id prefix."""
+    """Build a stable per-session adapter name, falling back to request_id for older clients."""
     if adapter_name is None or adapter_name == '':
         return None
-    return request.state.request_id + '-' + adapter_name
+    owner_id = get_session_id_from_request(request) or request.state.request_id
+    return owner_id + '-' + adapter_name
 
 
 def _register_twinkle_routes(app: FastAPI, self_fn: Callable[[], ModelManagement]) -> None:

--- a/src/twinkle/server/sampler/backends/mock_sampler.py
+++ b/src/twinkle/server/sampler/backends/mock_sampler.py
@@ -16,7 +16,7 @@ import numpy as np
 import time
 from typing import Any
 
-from twinkle import remote_class
+from twinkle import remote_class, remote_function
 from twinkle.data_format import SampledSequence, SampleResponse, SamplingParams
 from twinkle.utils.logger import get_logger
 from twinkle.utils.seed import stable_seed
@@ -44,6 +44,7 @@ class MockSampler:
 
     # ----- Sampler interface --------------------------------------------- #
 
+    @remote_function()
     def sample(
         self,
         inputs: Any,
@@ -85,6 +86,7 @@ class MockSampler:
             responses.append(SampleResponse(sequences=sequences))
         return responses
 
+    @remote_function()
     def sample_stream(
         self,
         inputs: Any,
@@ -111,20 +113,25 @@ class MockSampler:
         from . import stream_to_queue
         stream_to_queue(self, queue, inputs, sampling_params, adapter_name, adapter_path)
 
+    @remote_function()
     def apply_patch(self, patch_cls: Any, **kwargs: Any) -> None:
         return None
 
+    @remote_function()
     def set_template(self, template_cls: Any, **kwargs: Any) -> None:
         self.template = template_cls
 
+    @remote_function()
     def reset_prefix_cache(self) -> None:
         return None
 
     # ----- Adapter management -------------------------------------------- #
 
+    @remote_function()
     def add_adapter_to_sampler(self, adapter_name: str, config: Any) -> None:
         self._adapters[adapter_name] = config
 
+    @remote_function()
     def has_adapter(self, adapter_name: str) -> bool:
         return adapter_name in self._adapters
 

--- a/src/twinkle/server/sampler/tinker_handlers.py
+++ b/src/twinkle/server/sampler/tinker_handlers.py
@@ -69,8 +69,8 @@ def _register_tinker_sampler_routes(app: FastAPI, self_fn: Callable[[], SamplerM
                     checkpoint_manager = create_checkpoint_manager(token, client_type='tinker')
                     adapter_name, adapter_uri = checkpoint_manager.parse_adapter_uri(model_path)
 
-                # Validate adapter URI
-                if not adapter_uri or not os.path.exists(adapter_uri):
+                # Base-model sampling is valid when no model_path was provided.
+                if adapter_uri and not os.path.exists(adapter_uri):
                     return types.RequestFailedResponse(
                         error=f'Adapter URI {model_path} does not exist. Please check the model_path.',
                         category=types.RequestErrorCategory.User,

--- a/src/twinkle/server/sampler/twinkle_handlers.py
+++ b/src/twinkle/server/sampler/twinkle_handlers.py
@@ -25,6 +25,7 @@ import twinkle_client.types as types
 from twinkle.data_format import InputFeature, SamplingParams, Trajectory
 from twinkle.server.telemetry.correlation import MODEL_ID, TOKEN_ID
 from twinkle.server.telemetry.tracing import traced_operation
+from twinkle.server.utils.validation import get_session_id_from_request
 from twinkle.utils.logger import get_logger
 
 logger = get_logger()
@@ -49,10 +50,11 @@ def _serialize_input_feature(feature: dict) -> dict:
 
 
 def _get_twinkle_sampler_adapter_name(request: Request, adapter_name: str | None) -> str | None:
-    """Prefix the adapter name with the request ID for per-request isolation."""
+    """Build a stable per-session adapter name, falling back to request_id for older clients."""
     if adapter_name is None or adapter_name == '':
         return None
-    return request.state.request_id + '-' + adapter_name
+    owner_id = get_session_id_from_request(request) or request.state.request_id
+    return owner_id + '-' + adapter_name
 
 
 def _register_twinkle_sampler_routes(app: FastAPI, self_fn: Callable[[], SamplerManagement]) -> None:

--- a/src/twinkle/server/utils/task_queue/mixin.py
+++ b/src/twinkle/server/utils/task_queue/mixin.py
@@ -97,6 +97,7 @@ class TaskQueueMixin:
         input_tokens: int,
         batch_size: int | None = None,
         data_world_size: int | None = None,
+        batch_size_multiple: int | None = None,
     ) -> dict[str, Any] | None:
         """Run rate-limit and validation checks before queuing a task.
 
@@ -132,6 +133,22 @@ class TaskQueueMixin:
                     queue_state_reason=error_msg,
                 )
                 return {'request_id': request_id, 'model_id': model_id}
+            if batch_size_multiple is not None:
+                required_multiple = data_world_size * batch_size_multiple
+                if batch_size % required_multiple != 0:
+                    error_msg = (f'Batch size {batch_size} must be divisible by {required_multiple} '
+                                 f'so each data-parallel shard gets a multiple of '
+                                 f'{batch_size_multiple} examples')
+                    error_payload = {'error': error_msg, 'category': 'User'}
+                    await self.state.store_future_status(
+                        request_id,
+                        TaskStatus.FAILED.value,
+                        model_id,
+                        result=error_payload,
+                        queue_state=QueueState.UNKNOWN.value,
+                        queue_state_reason=error_msg,
+                    )
+                    return {'request_id': request_id, 'model_id': model_id}
 
         allowed, reason = await self._rate_limiter.check_and_record(token, input_tokens)
         if not allowed:
@@ -159,6 +176,7 @@ class TaskQueueMixin:
         input_tokens: int = 0,
         batch_size: int | None = None,
         data_world_size: int | None = None,
+        batch_size_multiple: int | None = None,
         task_type: str | None = None,
     ) -> dict[str, Any]:
         """Schedule a GPU compute task through the serial compute queue.
@@ -182,7 +200,7 @@ class TaskQueueMixin:
         request_id = f'req_{uuid.uuid4().hex}'
 
         preflight_result = await self._perform_preflight_checks(request_id, model_id, token, input_tokens, batch_size,
-                                                                data_world_size)
+                                                                data_world_size, batch_size_multiple)
         if preflight_result is not None:
             return preflight_result
 
@@ -229,6 +247,7 @@ class TaskQueueMixin:
         input_tokens: int = 0,
         batch_size: int | None = None,
         data_world_size: int | None = None,
+        batch_size_multiple: int | None = None,
         task_type: str | None = None,
     ) -> Any:
         """Schedule a compute task and block until it completes.
@@ -246,6 +265,7 @@ class TaskQueueMixin:
             input_tokens=input_tokens,
             batch_size=batch_size,
             data_world_size=data_world_size,
+            batch_size_multiple=batch_size_multiple,
             task_type=task_type,
         )
         request_id = future_ref.get('request_id')

--- a/tests/server/integration/openai_e2e.py
+++ b/tests/server/integration/openai_e2e.py
@@ -8,7 +8,6 @@
 
 import sys
 import time
-
 from openai import OpenAI
 
 BASE_URL = 'http://127.0.0.1:8000/api/v1'
@@ -31,8 +30,14 @@ def test_non_streaming(client: OpenAI):
     resp = client.chat.completions.create(
         model=MODEL,
         messages=[
-            {'role': 'system', 'content': 'You are a helpful assistant.'},
-            {'role': 'user', 'content': 'What is 2+2? Answer in one word.'},
+            {
+                'role': 'system',
+                'content': 'You are a helpful assistant.'
+            },
+            {
+                'role': 'user',
+                'content': 'What is 2+2? Answer in one word.'
+            },
         ],
         max_tokens=32,
         temperature=0.1,
@@ -56,7 +61,10 @@ def test_streaming(client: OpenAI):
     stream = client.chat.completions.create(
         model=MODEL,
         messages=[
-            {'role': 'user', 'content': 'Count from 1 to 5.'},
+            {
+                'role': 'user',
+                'content': 'Count from 1 to 5.'
+            },
         ],
         max_tokens=64,
         temperature=0.1,
@@ -70,7 +78,8 @@ def test_streaming(client: OpenAI):
         delta = chunk.choices[0].delta
         if delta.content:
             full_content += delta.content
-            print(f'  chunk: {delta.content[:60]!r}...' if len(delta.content or '') > 60 else f'  chunk: {delta.content!r}')
+            print(f'  chunk: {delta.content[:60]!r}...' if len(delta.content or '') >
+                  60 else f'  chunk: {delta.content!r}')
 
     elapsed = time.time() - t0
     print(f'  Total chunks: {len(chunks)}')
@@ -94,10 +103,22 @@ def test_multi_turn(client: OpenAI):
     resp = client.chat.completions.create(
         model=MODEL,
         messages=[
-            {'role': 'system', 'content': 'You are a math tutor.'},
-            {'role': 'user', 'content': 'What is 3*7?'},
-            {'role': 'assistant', 'content': '3*7 = 21'},
-            {'role': 'user', 'content': 'Now add 4 to that.'},
+            {
+                'role': 'system',
+                'content': 'You are a math tutor.'
+            },
+            {
+                'role': 'user',
+                'content': 'What is 3*7?'
+            },
+            {
+                'role': 'assistant',
+                'content': '3*7 = 21'
+            },
+            {
+                'role': 'user',
+                'content': 'Now add 4 to that.'
+            },
         ],
         max_tokens=32,
         temperature=0.1,
@@ -128,7 +149,10 @@ def test_sticky_session(base_url: str):
             f'{base_url}/chat/completions',
             json={
                 'model': MODEL,
-                'messages': [{'role': 'user', 'content': f'Say {i}.'}],
+                'messages': [{
+                    'role': 'user',
+                    'content': f'Say {i}.'
+                }],
                 'max_tokens': 5,
                 'temperature': 0.1,
             },
@@ -143,9 +167,7 @@ def test_sticky_session(base_url: str):
     # All requests with same model must hit the same replica
     unique = set(replica_ids)
     assert None not in unique, 'X-Twinkle-Replica-Id header missing from responses'
-    assert len(unique) == 1, (
-        f'Sticky session broken: requests routed to {len(unique)} different replicas: {unique}'
-    )
+    assert len(unique) == 1, (f'Sticky session broken: requests routed to {len(unique)} different replicas: {unique}')
     print(f'  All 5 requests → replica {replica_ids[0]}')
     print('  PASS\n')
 

--- a/tests/server/integration/openai_e2e.py
+++ b/tests/server/integration/openai_e2e.py
@@ -4,7 +4,7 @@
 # Tests both non-streaming and streaming /v1/chat/completions via OpenAI SDK.
 #
 # Usage:
-#   python -u openai_e2e.py
+#   python -u tests/server/integration/openai_e2e.py
 
 import sys
 import time

--- a/tests/server/integration/test_mock_mode_startup.py
+++ b/tests/server/integration/test_mock_mode_startup.py
@@ -305,6 +305,13 @@ def _exercise_tinker_client(base: str) -> None:
     training.forward_backward([datum], loss_fn='cross_entropy').result()
     training.optim_step(types.AdamParams(learning_rate=1e-4)).result()
 
+    base_sampling = client.create_sampling_client(base_model='mock-model')
+    base_sampling.sample(
+        prompt=types.ModelInput.from_ints([1, 2, 3]),
+        num_samples=1,
+        sampling_params=types.SamplingParams(max_tokens=4),
+    ).result()
+
     sampler_ckpt = training.save_weights_for_sampler(name='step-1').result()
     # Gateway's /asample resolves ``base_model`` from ``body.base_model`` or
     # ``sampling_session_id``; pass it explicitly because the SDK only sets

--- a/tests/server/integration/test_mock_mode_startup.py
+++ b/tests/server/integration/test_mock_mode_startup.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import httpx
 import os
 import pytest
+import subprocess
+import sys
 import time
 
 from tests.server.fixtures import MOCK_SERVER_CONFIG, MOCK_SERVER_CONFIG_REDIS
@@ -36,11 +38,25 @@ SELECTED_CONFIG = (
     MOCK_SERVER_CONFIG_REDIS if os.environ.get('TWINKLE_TEST_REDIS_PERSISTENCE', '0') == '1' else MOCK_SERVER_CONFIG)
 
 READY_BUDGET_SECONDS = 30.0
+RAY_NODE_CPUS = 8
+
+
+def _run_ray_command(*args: str) -> None:
+    ray_bin = os.path.join(os.path.dirname(sys.executable), 'ray')
+    result = subprocess.run(
+        [ray_bin, *args],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f'ray {" ".join(args)} failed with code {result.returncode}:\n{result.stdout}')
 
 
 @pytest.fixture(scope='module')
 def ray_cluster():
-    """Start a local Ray cluster for the duration of the module.
+    """Start a fresh local Ray head node for the duration of the module.
 
     Bypasses ``twinkle.server.launcher`` (which would normally inject
     ``TWINKLE_PERSISTENCE_*`` into the cluster), so we mirror that injection
@@ -60,11 +76,20 @@ def ray_cluster():
         for k, v in persistence_env.items():
             os.environ[k] = v
 
+    if ray.is_initialized():
+        ray.shutdown()
+    _run_ray_command('stop', '--force')
+    _run_ray_command(
+        'start',
+        '--head',
+        '--port=0',
+        f'--num-cpus={RAY_NODE_CPUS}',
+        '--num-gpus=0',
+        '--include-dashboard=false',
+        '--disable-usage-stats',
+    )
     ray.init(
-        num_cpus=4,
-        num_gpus=0,
-        ignore_reinit_error=True,
-        include_dashboard=False,
+        address='auto',
         runtime_env={'env_vars': persistence_env} if persistence_env else None,
     )
     yield
@@ -74,6 +99,10 @@ def ray_cluster():
         pass
     try:
         ray.shutdown()
+    except Exception:
+        pass
+    try:
+        _run_ray_command('stop', '--force')
     except Exception:
         pass
 
@@ -134,11 +163,8 @@ def test_mock_mode_reaches_ready_under_30s_and_is_deterministic(ray_cluster) -> 
             http_opts['port'] = port
             args.setdefault('http_options', http_opts)
         # Strip ray_actor_options runtime_env to keep the test light, BUT keep
-        # ``num_cpus`` low so the three deployments fit on a small local Ray
-        # cluster — Ray Serve defaults to ``num_cpus=1`` per replica when the
-        # field is absent, so without this each replica would need a full CPU
-        # and the cluster (2 CPUs after ``ignore_reinit_error=True`` silently
-        # accepts the existing one) would deadlock waiting for resources.
+        # ``num_cpus`` low so the three deployments leave room for the mock
+        # distributed runtime workers in the dedicated local Ray node.
         deploy_options: dict = {'ray_actor_options': {'num_cpus': 0.1}}
         for raw in app_spec.deployments:
             if isinstance(raw, dict):

--- a/tests/server/model/test_tinker_compat_output.py
+++ b/tests/server/model/test_tinker_compat_output.py
@@ -1,0 +1,113 @@
+import torch
+from tinker import types
+
+from twinkle.server.common.datum import extract_rl_features_for_loss
+from twinkle.server.model.backends.common import TwinkleCompatModelBase
+
+
+def _datum(seq_len: int, *, ref_logps=None, old_logps=None, advantages=None):
+    loss_fn_inputs = {
+        'target_tokens': types.TensorData.from_torch(torch.arange(seq_len, dtype=torch.long)),
+        'weights': types.TensorData.from_torch(torch.ones(seq_len)),
+    }
+    if ref_logps is not None:
+        loss_fn_inputs['ref_logps'] = types.TensorData.from_torch(torch.tensor(ref_logps, dtype=torch.float32))
+    if old_logps is not None:
+        loss_fn_inputs['logprobs'] = types.TensorData.from_torch(torch.tensor(old_logps, dtype=torch.float32))
+    if advantages is not None:
+        loss_fn_inputs['advantages'] = types.TensorData.from_torch(torch.tensor(advantages, dtype=torch.float32))
+    return types.Datum(
+        model_input=types.ModelInput.from_ints(list(range(seq_len))),
+        loss_fn_inputs=loss_fn_inputs,
+    )
+
+
+def test_tinker_build_output_handles_tensor_rows_from_transformers_backend():
+    inputs = [_datum(3), _datum(2)]
+    outputs = {'logps': torch.arange(8, dtype=torch.float32).view(2, 4)}
+
+    result = TwinkleCompatModelBase()._tinker_build_output(inputs, outputs)
+
+    assert [item['logprobs'].to_torch().tolist() for item in result] == [[0.0, 1.0, 2.0],
+                                                                         [4.0, 5.0]]
+    assert [item['elementwise_loss'].to_torch().tolist()
+            for item in result] == [[-0.0, -1.0, -2.0], [-4.0, -5.0]]
+
+
+def test_tinker_build_output_handles_ragged_microbatch_logps_from_megatron_backend():
+    inputs = [_datum(66), _datum(65), _datum(64), _datum(63)]
+    outputs = {
+        'logps': [
+            torch.ones(2, 66),
+            torch.full((2, 65), 2.0),
+        ]
+    }
+
+    result = TwinkleCompatModelBase()._tinker_build_output(inputs, outputs)
+
+    assert [item['logprobs'].to_torch().shape[0] for item in result] == [66, 65, 64, 63]
+    torch.testing.assert_close(result[0]['logprobs'].to_torch(), torch.ones(66))
+    torch.testing.assert_close(result[1]['logprobs'].to_torch(), torch.ones(65))
+    torch.testing.assert_close(result[2]['logprobs'].to_torch(), torch.full((64,), 2.0))
+    torch.testing.assert_close(result[3]['logprobs'].to_torch(), torch.full((63,), 2.0))
+
+
+def test_tinker_build_output_ignores_empty_pipeline_stage_outputs():
+    inputs = [_datum(3), _datum(2)]
+
+    result = TwinkleCompatModelBase()._tinker_build_output(inputs, {'logps': []})
+
+    assert result == []
+
+
+def test_tinker_build_output_handles_ragged_microbatch_logits_fallback():
+    inputs = [_datum(2), _datum(1), _datum(1)]
+    logits = [
+        torch.tensor([
+            [[10.0, 0.0], [0.0, 10.0]],
+            [[0.0, 10.0], [10.0, 0.0]],
+        ]),
+        torch.tensor([[[10.0, 0.0]]]),
+    ]
+
+    result = TwinkleCompatModelBase()._tinker_build_output(inputs, {'logits': logits})
+
+    assert len(result) == 3
+    assert [item['logprobs'].to_torch().shape[0] for item in result] == [2, 1, 1]
+
+
+def test_tinker_build_output_keeps_full_ragged_logps_for_dpo_reference_forward():
+    inputs = [_datum(3), _datum(2)]
+    outputs = {
+        'logps': [
+            torch.arange(5, dtype=torch.float32).view(1, 5),
+            torch.arange(4, dtype=torch.float32).view(1, 4),
+        ]
+    }
+
+    result = TwinkleCompatModelBase()._tinker_build_output(inputs, outputs, return_full_logprobs=True)
+
+    assert [item['logprobs'].to_torch().tolist() for item in result] == [
+        [0.0, 1.0, 2.0, 3.0, 4.0],
+        [0.0, 1.0, 2.0, 3.0],
+    ]
+
+
+def test_extract_rl_features_pads_ragged_dpo_ref_logps():
+    result = extract_rl_features_for_loss([
+        _datum(3, ref_logps=[1.0, 2.0, 3.0]),
+        _datum(2, ref_logps=[4.0, 5.0]),
+    ])
+
+    torch.testing.assert_close(result['ref_outputs']['logps'], torch.tensor([[1.0, 2.0, 3.0],
+                                                                             [4.0, 5.0, 0.0]]))
+
+
+def test_extract_rl_features_keeps_grpo_logps_and_advantages_ragged():
+    result = extract_rl_features_for_loss([
+        _datum(3, old_logps=[1.0, 2.0, 3.0], advantages=[0.5, 0.5, 0.5]),
+        _datum(2, old_logps=[4.0, 5.0], advantages=[-0.5, -0.5]),
+    ])
+
+    assert result['old_logps'] == [[1.0, 2.0, 3.0], [4.0, 5.0]]
+    assert result['advantages'] == [[0.5, 0.5, 0.5], [-0.5, -0.5]]

--- a/tests/server/model/test_tinker_compat_output.py
+++ b/tests/server/model/test_tinker_compat_output.py
@@ -1,3 +1,4 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
 import torch
 from tinker import types
 

--- a/tests/server/model/test_tinker_compat_output.py
+++ b/tests/server/model/test_tinker_compat_output.py
@@ -1,4 +1,3 @@
-# Copyright (c) ModelScope Contributors. All rights reserved.
 import torch
 from tinker import types
 
@@ -29,10 +28,8 @@ def test_tinker_build_output_handles_tensor_rows_from_transformers_backend():
 
     result = TwinkleCompatModelBase()._tinker_build_output(inputs, outputs)
 
-    assert [item['logprobs'].to_torch().tolist() for item in result] == [[0.0, 1.0, 2.0],
-                                                                         [4.0, 5.0]]
-    assert [item['elementwise_loss'].to_torch().tolist()
-            for item in result] == [[-0.0, -1.0, -2.0], [-4.0, -5.0]]
+    assert [item['logprobs'].to_torch().tolist() for item in result] == [[0.0, 1.0, 2.0], [4.0, 5.0]]
+    assert [item['elementwise_loss'].to_torch().tolist() for item in result] == [[-0.0, -1.0, -2.0], [-4.0, -5.0]]
 
 
 def test_tinker_build_output_handles_ragged_microbatch_logps_from_megatron_backend():
@@ -49,8 +46,8 @@ def test_tinker_build_output_handles_ragged_microbatch_logps_from_megatron_backe
     assert [item['logprobs'].to_torch().shape[0] for item in result] == [66, 65, 64, 63]
     torch.testing.assert_close(result[0]['logprobs'].to_torch(), torch.ones(66))
     torch.testing.assert_close(result[1]['logprobs'].to_torch(), torch.ones(65))
-    torch.testing.assert_close(result[2]['logprobs'].to_torch(), torch.full((64,), 2.0))
-    torch.testing.assert_close(result[3]['logprobs'].to_torch(), torch.full((63,), 2.0))
+    torch.testing.assert_close(result[2]['logprobs'].to_torch(), torch.full((64, ), 2.0))
+    torch.testing.assert_close(result[3]['logprobs'].to_torch(), torch.full((63, ), 2.0))
 
 
 def test_tinker_build_output_ignores_empty_pipeline_stage_outputs():
@@ -94,14 +91,54 @@ def test_tinker_build_output_keeps_full_ragged_logps_for_dpo_reference_forward()
     ]
 
 
+def test_tinker_build_output_splits_single_packed_logps_row():
+    inputs = [_datum(3), _datum(2)]
+    outputs = {'logps': torch.arange(5, dtype=torch.float32).view(1, 5)}
+
+    result = TwinkleCompatModelBase()._tinker_build_output(inputs, outputs, return_full_logprobs=True)
+
+    assert [item['logprobs'].to_torch().tolist() for item in result] == [[0.0, 1.0, 2.0], [3.0, 4.0]]
+
+
+def test_tinker_build_output_splits_batched_row_from_megatron_reference_forward():
+    inputs = [_datum(4), _datum(4)]
+    outputs = {'logps': torch.arange(8, dtype=torch.float32).view(1, 2, 4)}
+
+    result = TwinkleCompatModelBase()._tinker_build_output(inputs, outputs, return_full_logprobs=True)
+
+    assert [item['logprobs'].to_torch().tolist() for item in result] == [
+        [0.0, 1.0, 2.0, 3.0],
+        [4.0, 5.0, 6.0, 7.0],
+    ]
+
+
+def test_tinker_build_output_does_not_treat_packed_logits_as_batch_major():
+    inputs = [_datum(1), _datum(1)]
+    outputs = {'logits': torch.tensor([[[10.0, 0.0, 0.0], [0.0, 10.0, 0.0]]])}
+
+    result = TwinkleCompatModelBase()._tinker_build_output(inputs, outputs)
+
+    assert len(result) == 2
+    assert [item['logprobs'].to_torch().shape for item in result] == [torch.Size([1]), torch.Size([1])]
+
+
+def test_tinker_build_output_squeezes_singleton_reference_logps():
+    inputs = [_datum(4)]
+    outputs = {'logps': [torch.arange(4, dtype=torch.float32).view(1, 4)]}
+
+    result = TwinkleCompatModelBase()._tinker_build_output(inputs, outputs, return_full_logprobs=True)
+
+    assert result[0]['logprobs'].to_torch().shape == torch.Size([4])
+    assert result[0]['logprobs'].to_torch().tolist() == [0.0, 1.0, 2.0, 3.0]
+
+
 def test_extract_rl_features_pads_ragged_dpo_ref_logps():
     result = extract_rl_features_for_loss([
         _datum(3, ref_logps=[1.0, 2.0, 3.0]),
         _datum(2, ref_logps=[4.0, 5.0]),
     ])
 
-    torch.testing.assert_close(result['ref_outputs']['logps'], torch.tensor([[1.0, 2.0, 3.0],
-                                                                             [4.0, 5.0, 0.0]]))
+    torch.testing.assert_close(result['ref_outputs']['logps'], torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 0.0]]))
 
 
 def test_extract_rl_features_keeps_grpo_logps_and_advantages_ragged():

--- a/tests/server/model/test_tinker_handlers.py
+++ b/tests/server/model/test_tinker_handlers.py
@@ -1,0 +1,48 @@
+import pytest
+from fastapi import FastAPI
+from starlette.requests import Request
+from tinker import types
+
+from twinkle.server.model.tinker_handlers import _register_tinker_routes
+
+
+class _DummyManagement:
+
+    def __init__(self):
+        self.scheduled = []
+        self.data_world_size = 2
+
+    async def _on_request_start(self, request):
+        return 'token1'
+
+    async def schedule_task(self, task, **kwargs):
+        self.scheduled.append(kwargs)
+        return {'request_id': 'req1', 'model_id': kwargs.get('model_id')}
+
+
+def _datum():
+    return types.Datum(model_input=types.ModelInput.from_ints([1, 2]), loss_fn_inputs={})
+
+
+@pytest.mark.asyncio
+async def test_tinker_dpo_forward_backward_requires_per_dp_pairs():
+    management = _DummyManagement()
+    app = FastAPI()
+    _register_tinker_routes(app, lambda: management)
+
+    body = types.ForwardBackwardRequest(
+        model_id='model1',
+        forward_backward_input=types.ForwardBackwardInput(
+            data=[_datum(), _datum()],
+            loss_fn='importance_sampling',
+        ),
+    )
+
+    route = next(route for route in app.routes if getattr(route, 'path', None) == '/tinker/forward_backward')
+    request = Request({'type': 'http', 'headers': []})
+    response = await route.endpoint(request, body, management)
+
+    assert response == {'request_id': 'req1', 'model_id': 'model1'}
+    assert management.scheduled[-1]['batch_size'] == 2
+    assert management.scheduled[-1]['data_world_size'] == 2
+    assert management.scheduled[-1]['batch_size_multiple'] == 2

--- a/tests/server/sampler/test_tinker_handlers.py
+++ b/tests/server/sampler/test_tinker_handlers.py
@@ -1,5 +1,5 @@
-from fastapi import FastAPI
 import pytest
+from fastapi import FastAPI
 from starlette.requests import Request
 from tinker import types
 
@@ -31,14 +31,11 @@ class _DummySampler:
         self.adapter_paths.append(adapter_path)
         return [
             SampleResponse(
-                sequences=[
-                    SampledSequence(
-                        stop_reason='length',
-                        tokens=[1, 2],
-                        logprobs=[[(1, -0.1)], [(2, -0.2)]],
-                    )
-                ]
-            )
+                sequences=[SampledSequence(
+                    stop_reason='length',
+                    tokens=[1, 2],
+                    logprobs=[[(1, -0.1)], [(2, -0.2)]],
+                )])
         ]
 
 

--- a/tests/server/sampler/test_tinker_handlers.py
+++ b/tests/server/sampler/test_tinker_handlers.py
@@ -1,0 +1,77 @@
+from fastapi import FastAPI
+import pytest
+from starlette.requests import Request
+from tinker import types
+
+from twinkle.data_format import SampledSequence, SampleResponse
+from twinkle.server.sampler.tinker_handlers import _register_tinker_sampler_routes
+
+
+class _DummyState:
+
+    async def get_sampling_session(self, sampling_session_id: str):
+        return {
+            'base_model': 'mock-model',
+            'model_path': None,
+        }
+
+
+class _DummySampler:
+
+    def __init__(self):
+        self.adapter_paths = []
+
+    def set_template(self, *args, **kwargs):
+        return None
+
+    def reset_prefix_cache(self):
+        return None
+
+    def sample(self, inputs, sampling_params=None, adapter_name='', *, adapter_path=None, **kwargs):
+        self.adapter_paths.append(adapter_path)
+        return [
+            SampleResponse(
+                sequences=[
+                    SampledSequence(
+                        stop_reason='length',
+                        tokens=[1, 2],
+                        logprobs=[[(1, -0.1)], [(2, -0.2)]],
+                    )
+                ]
+            )
+        ]
+
+
+class _DummyManagement:
+
+    def __init__(self):
+        self.model_id = 'mock-model'
+        self.state = _DummyState()
+        self.sampler = _DummySampler()
+
+    async def _on_request_start(self, request):
+        return 'EMPTY_TOKEN'
+
+    async def schedule_task(self, task, **kwargs):
+        return await task()
+
+
+@pytest.mark.asyncio
+async def test_tinker_asample_allows_base_model_session_without_model_path():
+    management = _DummyManagement()
+    app = FastAPI()
+    _register_tinker_sampler_routes(app, lambda: management)
+
+    body = types.SampleRequest(
+        prompt=types.ModelInput.from_ints([1, 2, 3]),
+        sampling_params=types.SamplingParams(max_tokens=2),
+        sampling_session_id='base-session',
+        base_model='mock-model',
+    )
+
+    route = next(route for route in app.routes if getattr(route, 'path', None) == '/tinker/asample')
+    request = Request({'type': 'http', 'headers': []})
+    response = await route.endpoint(request, body, management)
+
+    assert isinstance(response, types.SampleResponse)
+    assert management.sampler.adapter_paths == [None]

--- a/tests/server/utils/test_task_queue_mixin.py
+++ b/tests/server/utils/test_task_queue_mixin.py
@@ -1,0 +1,67 @@
+import pytest
+
+from twinkle.server.utils.task_queue.config import TaskQueueConfig
+from twinkle.server.utils.task_queue.mixin import TaskQueueMixin
+
+
+class _DummyState:
+
+    def __init__(self):
+        self.records = []
+
+    async def store_future_status(self, *args, **kwargs):
+        self.records.append((args, kwargs))
+
+
+class _AllowingRateLimiter:
+
+    async def check_and_record(self, token, input_tokens):
+        return True, None
+
+
+class _DummyQueue(TaskQueueMixin):
+
+    def __init__(self):
+        self.state = _DummyState()
+        self._task_queue_config = TaskQueueConfig()
+        self._rate_limiter = _AllowingRateLimiter()
+        self._task_metrics = None
+        self._deployment_name = 'test'
+
+
+@pytest.mark.asyncio
+async def test_preflight_rejects_batch_without_per_dp_multiple():
+    queue = _DummyQueue()
+
+    result = await queue._perform_preflight_checks(
+        request_id='req1',
+        model_id='model1',
+        token='token1',
+        input_tokens=0,
+        batch_size=2,
+        data_world_size=2,
+        batch_size_multiple=2,
+    )
+
+    assert result == {'request_id': 'req1', 'model_id': 'model1'}
+    _, kwargs = queue.state.records[-1]
+    assert kwargs['result']['category'] == 'User'
+    assert 'Batch size 2 must be divisible by 4' in kwargs['result']['error']
+
+
+@pytest.mark.asyncio
+async def test_preflight_accepts_batch_with_per_dp_multiple():
+    queue = _DummyQueue()
+
+    result = await queue._perform_preflight_checks(
+        request_id='req1',
+        model_id='model1',
+        token='token1',
+        input_tokens=0,
+        batch_size=4,
+        data_world_size=2,
+        batch_size_multiple=2,
+    )
+
+    assert result is None
+    assert queue.state.records == []


### PR DESCRIPTION
## Summary

Sync the release/0.4.0 runtime fixes onto current main while preserving main-only package metadata and optional dependencies.


- upgrade the Tinker optional dependency to `tinker==0.16.1`
- add `ms-swift==4.1.3` to the Megatron extra
- align the Docker runtime with the release image, CUDA library path, pinned Redis/LGTM images, and tilelang runtime fix
- harden the Megatron server launch script around Redis shutdown/startup, LGTM readiness, and `twinkle.server launch`
- advertise the Megatron supported model in the server config
- sync the shared Tinker compat ragged-output handling for SFT/GRPO/DPO, including the empty pipeline-stage case

## Validation

- `conda run -n twinkle python -m pytest tests/server/model/test_tinker_compat_output.py -q`
- `conda run -n twinkle python -m pytest tests/server/model/test_mock_model.py -q`
- `conda run -n twinkle python -m pre_commit run --all-files`
