### PR TITLE
[doc] Fix broken cookbook links in README and README_ZH after directory reorganization

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,19 +92,19 @@ sh INSTALL_MEGATRON.sh
 | pp/tp/cp finetuning                  | megatron        | [Script](cookbook/megatron/tp.py)                      |
 | pp/tp/cp MoE finetuning              | megatron        | [Script](cookbook/megatron/tp_moe.py)                  |
 | Multimodal FSDP finetuning           | transformers    | [Script](cookbook/mm/fsdp2.py)                         |
-| GRPO RL training                     | megatron        | [Script](cookbook/rl/grpo.py)                          |
-| GRPO Multimodal RL training          | megatron        | [Script](cookbook/rl/grpo_mm.py)                       |
-| GRPO Math RL training                | megatron        | [Script](cookbook/rl/short_math_grpo.py)               |
-| DPO full-parameter training          | transformers    | [Script](cookbook/rl/dpo_full.py)                      |
-| DPO LoRA training                    | transformers    | [Script](cookbook/rl/dpo_lora.py)                      |
-| DPO multi-LoRA training              | transformers    | [Script](cookbook/rl/dpo_multi_lora.py)                |
-| GKD on-policy distillation           | megatron        | [Script](cookbook/rl/gkd_on_policy.py)                 |
-| GKD off-policy distillation          | megatron        | [Script](cookbook/rl/gkd_off_policy.py)                |
-| Tinker client finetuning (self-host) | transformers    | [Script](cookbook/server_mode/tinker/self_host)             |
-| Tinker client finetuning (ModelScope) | transformers   | [Script](cookbook/server_mode/tinker/modelscope)            |
-| Twinkle client finetuning (self-host) | transformers   | [Script](cookbook/server_mode/twinkle/self_host)            |
-| Twinkle client finetuning (ModelScope) | transformers  | [Script](cookbook/server_mode/twinkle/modelscope)           |
-| Server startup scripts               | transformers/megatron | [Script](cookbook/server_mode/server)                 |
+| GRPO RL training                     | megatron        | [Script](cookbook/rl/grpo/grpo.py)                          |
+| GRPO Multimodal RL training          | megatron        | [Script](cookbook/rl/grpo/grpo_mm.py)                       |
+| GRPO Math RL training                | megatron        | [Script](cookbook/rl/grpo/short_math_grpo.py)               |
+| DPO full-parameter training          | transformers    | [Script](cookbook/rl/dpo/dpo_full.py)                      |
+| DPO LoRA training                    | transformers    | [Script](cookbook/rl/dpo/dpo_lora.py)                      |
+| DPO multi-LoRA training              | transformers    | [Script](cookbook/rl/dpo/dpo_multi_lora.py)                |
+| GKD on-policy distillation           | megatron        | [Script](cookbook/rl/gkd/gkd_on_policy.py)                 |
+| GKD off-policy distillation          | megatron        | [Script](cookbook/rl/gkd/gkd_off_policy.py)                |
+| Tinker client finetuning (self-host) | transformers    | [Script](cookbook/client/tinker/self_host)             |
+| Tinker client finetuning (ModelScope) | transformers   | [Script](cookbook/client/tinker/modelscope)            |
+| Twinkle client finetuning (self-host) | transformers   | [Script](cookbook/client/twinkle/self_host)            |
+| Twinkle client finetuning (ModelScope) | transformers  | [Script](cookbook/client/twinkle/modelscope)           |
+| Server startup scripts               | transformers/megatron | [Script](cookbook/client/server)                 |
 
 ## Changelog
 - 🎉2026-05-20 Support DeepSeek-V4-Flash and DeepSeek-V4-Pro models.
@@ -113,9 +113,9 @@ sh INSTALL_MEGATRON.sh
 - 🎉2026-04-27 Support the `padding_free` operation for sft/dpo/grpo/gkd, use `set_processor('InputProcessor', padding_free=True)` to train with it.
 - 🎉2026-04-22 The ModelScope service has been deployed to [Qwen/Qwen3.6-27B](https://www.modelscope.cn/models/Qwen/Qwen3.6-27B) with a new release 0.2.1.
 - 🎉2026-04-14 The ModelScope service has been deployed to [Qwen/Qwen3.6-35B-A3B](https://www.modelscope.cn/models/Qwen/Qwen3.6-35B-A3B) with a new release 0.2.0.
-- 🎉2026-03-28 Support DPO training with both Transformers and Megatron backends. See [dpo_full.py](cookbook/rl/dpo_full.py) and [dpo_lora.py](cookbook/rl/dpo_lora.py).
+- 🎉2026-03-28 Support DPO training with both Transformers and Megatron backends. See [dpo_full.py](cookbook/rl/dpo/dpo_full.py) and [dpo_lora.py](cookbook/rl/dpo/dpo_lora.py).
 - 🎉2026-03-24 Twinkle Web site is now live at https://modelscope.github.io/twinkle-web/
-- 🎉2026-03-19 Support GKD training, please refer to this [cookbook](cookbook/rl/gkd_on_policy.py).
+- 🎉2026-03-19 Support GKD training, please refer to this [cookbook](cookbook/rl/gkd/gkd_on_policy.py).
 - 🎉2026-02-13 Initial version of Twinkle✨ released, including SFT/PT/RL support for text models.
 
 ## Training as a Service on ModelScope

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -86,19 +86,19 @@ sh INSTALL_MEGATRON.sh
 | pp/tp/cp 微调                       | megatron              | [脚本](cookbook/megatron/tp.py)                        |
 | pp/tp/cp MoE 微调                   | megatron              | [脚本](cookbook/megatron/tp_moe.py)                    |
 | 多模态 FSDP 微调                    | transformers          | [脚本](cookbook/mm/fsdp2.py)                           |
-| GRPO 强化学习训练                    | megatron              | [脚本](cookbook/rl/grpo.py)                            |
-| GRPO 多模态强化学习训练             | megatron              | [脚本](cookbook/rl/grpo_mm.py)                         |
-| GRPO 数学强化学习训练               | megatron              | [脚本](cookbook/rl/short_math_grpo.py)                 |
-| DPO 全参数训练                      | transformers          | [脚本](cookbook/rl/dpo_full.py)                        |
-| DPO LoRA 训练                       | transformers          | [脚本](cookbook/rl/dpo_lora.py)                        |
-| DPO 多 LoRA 训练                    | transformers          | [脚本](cookbook/rl/dpo_multi_lora.py)                  |
-| GKD 在线蒸馏                        | megatron              | [脚本](cookbook/rl/gkd_on_policy.py)                   |
-| GKD 离线蒸馏                        | megatron              | [脚本](cookbook/rl/gkd_off_policy.py)                  |
-| Tinker 客户端微调（自部署）         | transformers          | [脚本](cookbook/server_mode/tinker/self_host)               |
-| Tinker 客户端微调（ModelScope）      | transformers          | [脚本](cookbook/server_mode/tinker/modelscope)              |
-| Twinkle 客户端微调（自部署）        | transformers          | [脚本](cookbook/server_mode/twinkle/self_host)              |
-| Twinkle 客户端微调（ModelScope）     | transformers          | [脚本](cookbook/server_mode/twinkle/modelscope)             |
-| 服务端启动脚本                      | transformers/megatron | [脚本](cookbook/server_mode/server)                         |
+| GRPO 强化学习训练                    | megatron              | [脚本](cookbook/rl/grpo/grpo.py)                            |
+| GRPO 多模态强化学习训练             | megatron              | [脚本](cookbook/rl/grpo/grpo_mm.py)                         |
+| GRPO 数学强化学习训练               | megatron              | [脚本](cookbook/rl/grpo/short_math_grpo.py)                 |
+| DPO 全参数训练                      | transformers          | [脚本](cookbook/rl/dpo/dpo_full.py)                        |
+| DPO LoRA 训练                       | transformers          | [脚本](cookbook/rl/dpo/dpo_lora.py)                        |
+| DPO 多 LoRA 训练                    | transformers          | [脚本](cookbook/rl/dpo/dpo_multi_lora.py)                  |
+| GKD 在线蒸馏                        | megatron              | [脚本](cookbook/rl/gkd/gkd_on_policy.py)                   |
+| GKD 离线蒸馏                        | megatron              | [脚本](cookbook/rl/gkd/gkd_off_policy.py)                  |
+| Tinker 客户端微调（自部署）         | transformers          | [脚本](cookbook/client/tinker/self_host)               |
+| Tinker 客户端微调（ModelScope）      | transformers          | [脚本](cookbook/client/tinker/modelscope)              |
+| Twinkle 客户端微调（自部署）        | transformers          | [脚本](cookbook/client/twinkle/self_host)              |
+| Twinkle 客户端微调（ModelScope）     | transformers          | [脚本](cookbook/client/twinkle/modelscope)             |
+| 服务端启动脚本                      | transformers/megatron | [脚本](cookbook/client/server)                         |
 
 Twinkle✨支持相同的算法接口运行在单GPU、torchrun多机、Ray、Client等各场景下。其算法过程是外露的，非常便于修改和调试。完整的框架介绍请查看[快速开始](https://modelscope.github.io/twinkle-web/zh/docs/usage-guide/quick-start/)
 
@@ -109,9 +109,9 @@ Twinkle✨支持相同的算法接口运行在单GPU、torchrun多机、Ray、Cl
 - 🎉2026-04-27 支持sft/dpo/grpo/gkd的padding_free方法, 使用`set_processor('InputProcessor', padding_free=True)`来开启训练。
 - 🎉2026-04-22 ModelScope的训练服务部署为[Qwen/Qwen3.6-27B](https://www.modelscope.cn/models/Qwen/Qwen3.6-27B)，并发布了0.2.1版本。
 - 🎉2026-04-16 ModelScope的训练服务部署为[Qwen/Qwen3.6-35B-A3B](https://www.modelscope.cn/models/Qwen/Qwen3.6-35B-A3B)，并发布了0.2.0版本。
-- 🎉2026-03-28 支持 DPO 训练，同时支持 Transformers 和 Megatron 后端。参考 [dpo_full.py](cookbook/rl/dpo_full.py) 和 [dpo_lora.py](cookbook/rl/dpo_lora.py)。
+- 🎉2026-03-28 支持 DPO 训练，同时支持 Transformers 和 Megatron 后端。参考 [dpo_full.py](cookbook/rl/dpo/dpo_full.py) 和 [dpo_lora.py](cookbook/rl/dpo/dpo_lora.py)。
 - 🎉2026-03-24 Twinkle 站点上线，访问地址 https://modelscope.github.io/twinkle-web/
-- 🎉2026-03-19 支持 GKD 蒸馏能力，参考 [cookbook](cookbook/rl/gkd_on_policy.py)。
+- 🎉2026-03-19 支持 GKD 蒸馏能力，参考 [cookbook](cookbook/rl/gkd/gkd_on_policy.py)。
 - 🎉2026-02-13 Twinkle✨ 初始版本发布，支持文本模型的SFT/PT/RL训练。我们还通过兼容Tinker的API，在魔搭社区上提供了无服务器训练功能。
 
 ## ModelScope 的训练服务


### PR DESCRIPTION
## 背景
cookbook 目录近期重组(commit f41c5f4, PR #241),将 `cookbook/rl/*.py` 拆入 `grpo/dpo/gkd` 子目录,`cookbook/server_mode/` 重命名为 `cookbook/client/`,但 README 中的教程链接未同步,导致 32 处死链。

## 改动
修复 README.md 和 README_ZH.md 中共 32 处死链(每文件 16 处),仅替换括号内路径,未动其它文字、格式或对齐。

### Tutorials 表格(每文件 13 处)
- `cookbook/rl/grpo.py` 等 8 处 → 插入 `grpo/` / `dpo/` / `gkd/` 子目录
- `cookbook/server_mode/...` 5 处 → `cookbook/client/...`

### Changelog(每文件 3 处)
- `cookbook/rl/dpo_full.py`、`cookbook/rl/dpo_lora.py`、`cookbook/rl/gkd_on_policy.py` 路径同步

## 验证
- 所有新路径已通过仓库 Contents API 确认存在(HTTP 200)
- 通过 GitHub Code Search 确认旧路径(`cookbook/rl/grpo.py`、`cookbook/server_mode` 等)仅存在于 README.md / README_ZH.md,`docs/` 目录无相关死链,改动范围完整
- 纯文档变更,无代码逻辑改动

## 影响范围
仅 README.md + README_ZH.md