### PR TITLE
Add mindspeed dependency check for NPU-specific paths (FLA & Megatron)

### DIFF
--- a/src/twinkle/kernel/builtin.py
+++ b/src/twinkle/kernel/builtin.py
@@ -86,8 +86,14 @@ def npu_builtin(model: nn.Module | None = None) -> dict[Any, dict[str, Any]]:
 
     # === FLA (side-effect; mapping-incompatible) ===
     if is_npu_platform:
-        apply_qwen3_5_fla(model)
-
+        from twinkle.utils.import_utils import exists
+        if exists('mindspeed'):
+            apply_qwen3_5_fla(model)
+        else:
+            logger.warning('[NPU] [FLA] mindspeed is not installed; '
+                           'FLA patch for Qwen3.5 requires mindspeed. '
+                           'Install it with: pip install mindspeed. '
+                           'Other NPU patches will still apply.')
     return bundle
 
 

--- a/src/twinkle/kernel/builtin.py
+++ b/src/twinkle/kernel/builtin.py
@@ -87,12 +87,12 @@ def npu_builtin(model: nn.Module | None = None) -> dict[Any, dict[str, Any]]:
     # === FLA (side-effect; mapping-incompatible) ===
     if is_npu_platform:
         from twinkle.utils.import_utils import exists
-        if exists('mindspeed'):
+        if exists('mindspeed>=0.12.1') and exists('flash-linear-attention'):
             apply_qwen3_5_fla(model)
         else:
-            logger.warning('[NPU] [FLA] mindspeed is not installed; '
-                           'FLA patch for Qwen3.5 requires mindspeed. '
-                           'Install it with: pip install mindspeed. '
+            logger.warning('[NPU] [FLA] mindspeed or flash-linear-attention is not installed, or mindspeed version smaller than 0.12.1; '
+                           'FLA patch for Qwen3.5 requires mindspeed and flash-linear-attention. '
+                           'Install them with: pip install flash-linear-attention and mindspeed from source code via https://gitcode.com/Ascend/MindSpeed.'
                            'Other NPU patches will still apply.')
     return bundle
 

--- a/src/twinkle/model/megatron/_mindspeed_runtime.py
+++ b/src/twinkle/model/megatron/_mindspeed_runtime.py
@@ -35,6 +35,7 @@ def ensure_mindspeed_adaptor_patched() -> None:
     global _MINDSPEED_IMPORTED
     if not _is_npu() or _MINDSPEED_IMPORTED:
         return
+    requires('mindspeed')
     import mindspeed.megatron_adaptor  # noqa: F401
     _MINDSPEED_IMPORTED = True
 

--- a/src/twinkle/model/megatron/_mindspeed_runtime.py
+++ b/src/twinkle/model/megatron/_mindspeed_runtime.py
@@ -35,6 +35,7 @@ def ensure_mindspeed_adaptor_patched() -> None:
     global _MINDSPEED_IMPORTED
     if not _is_npu() or _MINDSPEED_IMPORTED:
         return
+    from twinkle.utils.import_utils import requires
     requires('mindspeed')
     import mindspeed.megatron_adaptor  # noqa: F401
     _MINDSPEED_IMPORTED = True


### PR DESCRIPTION
## Motivation

Some NPU patches depend on `mindspeed`, but lacked explicit dependency checks:
- The FLA patch silently skipped when mindspeed was missing (`try/except` + warning), making it hard for users to notice
- The Megatron NPU path had no upfront check, crashing at runtime only when mindspeed was absent

## Changes

1. **`kernel/builtin.py`** — Guard the FLA section with `exists('mindspeed')`: if present, enable FLA; if missing, log a warning and skip FLA while letting other NPU patches apply normally.
2. **`model/megatron/megatron.py` & `multi_lora_megatron.py`** — Add `requires('mindspeed')` in src/twinkle/model/megatron/_mindspeed_runtime.py