### PR TITLE
fix: 修改visible_device参数报错和dense模型没有_router_replay_enabled属性报错

### DIFF
--- a/src/twinkle/kernel/builtin.py
+++ b/src/twinkle/kernel/builtin.py
@@ -90,10 +90,11 @@ def npu_builtin(model: nn.Module | None = None) -> dict[Any, dict[str, Any]]:
         if exists('mindspeed>=0.12.1') and exists('flash-linear-attention'):
             apply_qwen3_5_fla(model)
         else:
-            logger.warning('[NPU] [FLA] mindspeed or flash-linear-attention is not installed, or mindspeed version smaller than 0.12.1; '
-                           'FLA patch for Qwen3.5 requires mindspeed and flash-linear-attention. '
-                           'Install them with: pip install flash-linear-attention and mindspeed from source code via https://gitcode.com/Ascend/MindSpeed.'
-                           'Other NPU patches will still apply.')
+            logger.warning(
+                '[NPU] [FLA] mindspeed or flash-linear-attention is not installed, or mindspeed version smaller than 0.12.1; '
+                'FLA patch for Qwen3.5 requires mindspeed and flash-linear-attention. '
+                'Install them with: pip install flash-linear-attention and mindspeed from source code via https://gitcode.com/Ascend/MindSpeed.'
+                'Other NPU patches will still apply.')
     return bundle
 
 

--- a/src/twinkle/kernel/builtin.py
+++ b/src/twinkle/kernel/builtin.py
@@ -90,11 +90,13 @@ def npu_builtin(model: nn.Module | None = None) -> dict[Any, dict[str, Any]]:
         if exists('mindspeed>=0.12.1') and exists('flash-linear-attention'):
             apply_qwen3_5_fla(model)
         else:
-            logger.warning(
-                '[NPU] [FLA] mindspeed or flash-linear-attention is not installed, or mindspeed version smaller than 0.12.1; '
-                'FLA patch for Qwen3.5 requires mindspeed and flash-linear-attention. '
-                'Install them with: pip install flash-linear-attention and mindspeed from source code via https://gitcode.com/Ascend/MindSpeed.'
-                'Other NPU patches will still apply.')
+            logger.warning('[NPU] [FLA] mindspeed or flash-linear-attention is not installed, '
+                           'or mindspeed version smaller than 0.12.1; '
+                           'FLA patch for Qwen3.5 requires mindspeed and flash-linear-attention. '
+                           'Install them with: pip install flash-linear-attention, '
+                           'and install mindspeed from source code via '
+                           'https://gitcode.com/Ascend/MindSpeed. '
+                           'Other NPU patches will still apply.')
     return bundle
 
 

--- a/src/twinkle/model/transformers/transformers.py
+++ b/src/twinkle/model/transformers/transformers.py
@@ -384,7 +384,7 @@ class TransformersModel(TwinkleModel, PreTrainedModel, CheckpointEngineMixin):
         Returns ``cleanup_fn``.
         Call *cleanup_fn* after the forward to gather recorded indices(when RECORD) and clear global state.
         """
-        if not self._router_replay_enabled:
+        if not getattr(self, '_router_replay_enabled', False):
             return lambda: None
 
         self._maybe_apply_router_replay()

--- a/src/twinkle/utils/device_mesh.py
+++ b/src/twinkle/utils/device_mesh.py
@@ -538,6 +538,7 @@ class DeviceGroup:
     ranks: Union[List[int], int]
     device_type: str
     gpus_per_worker: int = 1
+    visible_devices: Optional[Union[List[str],List[int], str, int]] = None
     _device_mesh: Dict[str, DeviceMesh] = field(default_factory=dict)
 
 

--- a/src/twinkle/utils/device_mesh.py
+++ b/src/twinkle/utils/device_mesh.py
@@ -538,7 +538,7 @@ class DeviceGroup:
     ranks: Union[List[int], int]
     device_type: str
     gpus_per_worker: int = 1
-    visible_devices: Optional[Union[List[str],List[int], str, int]] = None
+    visible_devices: Optional[Union[List[str], List[int], str, int]] = None
     _device_mesh: Dict[str, DeviceMesh] = field(default_factory=dict)
 
 


### PR DESCRIPTION
# PR type
- [ √] Bug Fix
- [ ] New Feature
- [ ] Document Updates
- [ ] More Models or Datasets Support

# PR information
本次 PR 修复了两个导致模型加载和 Server 启动失败的 Bug：

1. 修复 Dense 模型加载报错 (AttributeError)
- 文件：src/twinkle/model/transformers/transformers.py
- 原因：代码直接访问 self._router_replay_enabled，但 Dense 模型并未初始化该属性。
- 修改：改用 getattr(self, '_router_replay_enabled', False) 进行安全访问，兼容 Dense 模型。

2. 修复 Server 启动报错 (TypeError)
- 文件：src/twinkle/server/model/app.py (DeviceGroup 类)
- 原因：device_utils.py 中的装饰器会自动将环境变量（如 CUDA_VISIBLE_DEVICES）注入到 device_group 字典的 visible_devices 字段中，但 DeviceGroup 类未定义该参数，导致实例化时参数不匹配报错。
- 修改：在 DeviceGroup 类中补充 visible_devices 字段，以正确接收该参数。

