### PR TITLE
feat: add DashServing HTTP adapter

### DIFF
--- a/cookbook/client/server/megatron/entrypoint.sh
+++ b/cookbook/client/server/megatron/entrypoint.sh
@@ -7,13 +7,19 @@ set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUN_SCRIPT="$SCRIPT_DIR/run.sh"
-TWINKLE_WORK_DIR="${TWINKLE_WORK_DIR:-/dashscope/caches/application/twinkle}"
-TEMP_DIR="${TWINKLE_TEMP_DIR:-/dashscope/caches/application/ray_logs}"
-export MODELSCOPE_CACHE="${MODELSCOPE_CACHE:-/dashscope/caches/application/.cache}"
+TWINKLE_RUNTIME_DIR="${TWINKLE_RUNTIME_DIR:-/twinkle/runtime}"
+TWINKLE_WORK_DIR="${TWINKLE_WORK_DIR:-$TWINKLE_RUNTIME_DIR/work}"
+TEMP_DIR="${TWINKLE_TEMP_DIR:-$TWINKLE_RUNTIME_DIR/ray_logs}"
+export MODELSCOPE_CACHE="${MODELSCOPE_CACHE:-$TWINKLE_RUNTIME_DIR/.cache}"
 export FLA_TILELANG="${FLA_TILELANG:-0}"
 LOG_FILE="$TWINKLE_WORK_DIR/run.log"
-TWINKLE_HEALTH_URL="${TWINKLE_HEALTH_URL:-http://127.0.0.1:9000/api/v1/healthz}"
-TWINKLE_DEEP_HEALTH_URL="${TWINKLE_DEEP_HEALTH_URL:-http://127.0.0.1:9000/api/v1/twinkle/healthz/deep}"
+TWINKLE_DASHSERVING_ADAPTER="${TWINKLE_DASHSERVING_ADAPTER:-0}"
+if [ "$TWINKLE_DASHSERVING_ADAPTER" = "1" ]; then
+    TWINKLE_HEALTH_URL="${TWINKLE_HEALTH_URL:-http://127.0.0.1:${PORT:-9000}/health}"
+else
+    TWINKLE_HEALTH_URL="${TWINKLE_HEALTH_URL:-http://127.0.0.1:8000/api/v1/healthz}"
+fi
+TWINKLE_DEEP_HEALTH_URL="${TWINKLE_DEEP_HEALTH_URL:-http://127.0.0.1:8000/api/v1/twinkle/healthz/deep}"
 TWINKLE_WATCHDOG_INTERVAL_SECONDS="${TWINKLE_WATCHDOG_INTERVAL_SECONDS:-10}"
 TWINKLE_WATCHDOG_FAILURE_THRESHOLD="${TWINKLE_WATCHDOG_FAILURE_THRESHOLD:-3}"
 TWINKLE_RAY_GRACE_SECONDS="${TWINKLE_RAY_GRACE_SECONDS:-30}"
@@ -66,6 +72,14 @@ validate_entrypoint_config() {
     require_non_negative_int "TWINKLE_HEALTH_GRACE_SECONDS" "$TWINKLE_HEALTH_GRACE_SECONDS"
     require_non_negative_int "TWINKLE_DEEP_HEALTH_GRACE_SECONDS" "$TWINKLE_DEEP_HEALTH_GRACE_SECONDS"
     require_non_negative_int "TWINKLE_ENTRYPOINT_RESTART_BACKOFF_SECONDS" "$RESTART_BACKOFF_SECONDS"
+
+    case "$TWINKLE_DASHSERVING_ADAPTER" in
+        0|1) ;;
+        *)
+            print_error "TWINKLE_DASHSERVING_ADAPTER 只能是 0 或 1，当前值: $TWINKLE_DASHSERVING_ADAPTER"
+            exit 1
+            ;;
+    esac
 
     require_command timeout
     require_command ray

--- a/cookbook/client/server/megatron/run.sh
+++ b/cookbook/client/server/megatron/run.sh
@@ -3,7 +3,8 @@
 # ============================================
 # Twinkle Megatron 服务启动脚本
 # ============================================
-# 功能：启动 Ray 集群（支持多 GPU/CPU 节点）、LGTM 观测栈和 Twinkle 服务器
+# 功能：启动 Ray 集群（支持多 GPU/CPU 节点）、LGTM 观测栈和 Twinkle 服务器。
+# 设置 TWINKLE_DASHSERVING_ADAPTER=1 时，同时启动 ASI Native HTTP Adapter。
 #
 # 用法：./run.sh [选项]
 #
@@ -12,14 +13,15 @@
 #   --head NODE          Head 节点 GPU 设备列表，逗号分隔 (默认: 0,1,2,3)
 #   --gpu-workers LIST   GPU Worker 列表，分号分隔多个节点 (默认: 4,5,6,7)
 #   --cpu-workers N      CPU Worker 数量 (默认: 1)
-#   --temp-dir DIR       Ray 临时目录 (默认: /dashscope/caches/application/ray_logs)
-#   --save-dir DIR       Twinkle 模型保存目录 (默认: /dashscope/caches/application/save)
+#   --temp-dir DIR       Ray 临时目录 (默认: /twinkle/runtime/ray_logs)
+#   --save-dir DIR       Twinkle 模型保存目录 (默认: /twinkle/runtime/save)
 #   --server-config FILE Twinkle 服务器配置文件路径 (默认: /twinkle/cookbook/client/server/megatron/server_config.yaml)
 #   --help               显示帮助信息
 #
 # 环境变量：
-#   MODELSCOPE_CACHE                         默认 /dashscope/caches/application/.cache
-#   TWINKLE_WORK_DIR                         默认 /dashscope/caches/application/twinkle
+#   MODELSCOPE_CACHE                         默认 /twinkle/runtime/.cache
+#   TWINKLE_WORK_DIR                         默认 /twinkle/runtime/work
+#   TWINKLE_DASHSERVING_ADAPTER              设为 1 时启动端口 9000 的 Adapter
 #   TWINKLE_RUN_EXISTING_ACTION              已有 run.sh 进程运行时的行为：exit 或 restart（默认 exit）
 #   TWINKLE_RUN_RESTART_TIMEOUT_SECONDS      --restart 等待已有实例接收请求秒数（默认 120）
 #
@@ -61,12 +63,13 @@ RAY_PORT=6379
 RAY_ADDRESS="127.0.0.1:$RAY_PORT"
 
 # --- 路径配置 ---
-export MODELSCOPE_CACHE="${MODELSCOPE_CACHE:-/dashscope/caches/application/.cache}"
-TWINKLE_WORK_DIR="${TWINKLE_WORK_DIR:-/dashscope/caches/application/twinkle}"
-DEFAULT_TEMP_DIR="/dashscope/caches/application/ray_logs"
+TWINKLE_RUNTIME_DIR="${TWINKLE_RUNTIME_DIR:-/twinkle/runtime}"
+export MODELSCOPE_CACHE="${MODELSCOPE_CACHE:-$TWINKLE_RUNTIME_DIR/.cache}"
+TWINKLE_WORK_DIR="${TWINKLE_WORK_DIR:-$TWINKLE_RUNTIME_DIR/work}"
+DEFAULT_TEMP_DIR="${TWINKLE_TEMP_DIR:-$TWINKLE_RUNTIME_DIR/ray_logs}"
 LOG_FILE="run.log"
 REDIS_LOG_FILE="/twinkle/redis.log"
-DEFAULT_SAVE_DIR="/dashscope/caches/application/save"
+DEFAULT_SAVE_DIR="${TWINKLE_SAVE_DIR:-$TWINKLE_RUNTIME_DIR/save}"
 DEFAULT_SERVER_CONFIG_FILE="/twinkle/cookbook/client/server/megatron/server_config.yaml"
 
 # --- LGTM 版本配置（与 grafana/otel-lgtm:0.28.0 保持一致） ---
@@ -87,8 +90,10 @@ TWINKLE_RUN_RESTART_REQUEST_FILE="${TWINKLE_RUN_RESTART_REQUEST_FILE:-/tmp/twink
 TWINKLE_RUN_EXISTING_ACTION="${TWINKLE_RUN_EXISTING_ACTION:-exit}"
 TWINKLE_RUN_RESTART_TIMEOUT_SECONDS="${TWINKLE_RUN_RESTART_TIMEOUT_SECONDS:-120}"
 SERVER_PID=""
+ADAPTER_PID=""
 TAIL_PID=""
 RESTART_REQUESTED_BY_SIGNAL=0
+TWINKLE_DASHSERVING_ADAPTER="${TWINKLE_DASHSERVING_ADAPTER:-0}"
 
 # ============================================
 # 参数解析（支持 --key=value 或 --key value 格式）
@@ -117,8 +122,9 @@ print_usage() {
   --help, -h           显示帮助信息
 
 环境变量:
-  MODELSCOPE_CACHE                         默认: /dashscope/caches/application/.cache
-  TWINKLE_WORK_DIR                         默认: /dashscope/caches/application/twinkle
+  MODELSCOPE_CACHE                         默认: /twinkle/runtime/.cache
+  TWINKLE_WORK_DIR                         默认: /twinkle/runtime/work
+  TWINKLE_DASHSERVING_ADAPTER              设为 1 时启动端口 9000 的 Adapter
   TWINKLE_RUN_EXISTING_ACTION              已有 run.sh 进程运行时的行为：exit 或 restart (默认: exit)
   TWINKLE_RUN_RESTART_TIMEOUT_SECONDS      --restart 等待已有实例接收请求秒数 (默认: 120)
 
@@ -397,6 +403,13 @@ validate_runtime_config() {
 
     require_positive_int "TWINKLE_RUN_RESTART_TIMEOUT_SECONDS" "$TWINKLE_RUN_RESTART_TIMEOUT_SECONDS"
     require_non_negative_int "CPU_WORKER_COUNT" "$CPU_WORKER_COUNT"
+    case "$TWINKLE_DASHSERVING_ADAPTER" in
+        0|1) ;;
+        *)
+            print_error "TWINKLE_DASHSERVING_ADAPTER 只能是 0 或 1，当前值: $TWINKLE_DASHSERVING_ADAPTER"
+            exit 1
+            ;;
+    esac
 }
 
 require_command() {
@@ -493,8 +506,10 @@ stop_pid() {
 
 cleanup_existing_runtime() {
     stop_pid "$TAIL_PID" "日志 tail"
+    stop_pid "$ADAPTER_PID" "DashServing Adapter"
     stop_pid "$SERVER_PID" "Twinkle Server"
     TAIL_PID=""
+    ADAPTER_PID=""
     SERVER_PID=""
 
     print_info "停止已有的 Twinkle Server..."
@@ -742,6 +757,20 @@ start_twinkle_server() {
     start_log_tail
 }
 
+start_dashserving_adapter() {
+    if [ "$TWINKLE_DASHSERVING_ADAPTER" != "1" ]; then
+        return
+    fi
+
+    print_header "启动 DashServing Adapter"
+    export PORT="${PORT:-9000}"
+    export TWINKLE_INTERNAL_URL="${TWINKLE_INTERNAL_URL:-http://127.0.0.1:8000}"
+    export TWINKLE_DS_TIMEOUT_SECONDS="${TWINKLE_DS_TIMEOUT_SECONDS:-600}"
+    nohup python -m twinkle.server.dashserving >> "$LOG_FILE" 2>&1 &
+    ADAPTER_PID=$!
+    print_success "DashServing Adapter 已启动 (PID: $ADAPTER_PID, port: $PORT)"
+}
+
 wait_runtime() {
     print_info "Twinkle runtime 已启动，等待 server 进程..."
     while true; do
@@ -751,6 +780,12 @@ wait_runtime() {
 
         if ! kill -0 "$SERVER_PID" 2>/dev/null; then
             print_error "Twinkle Server 进程已退出 (PID: $SERVER_PID)"
+            return 1
+        fi
+
+        if [ "$TWINKLE_DASHSERVING_ADAPTER" = "1" ] \
+            && ! kill -0 "$ADAPTER_PID" 2>/dev/null; then
+            print_error "DashServing Adapter 进程已退出 (PID: $ADAPTER_PID)"
             return 1
         fi
 
@@ -772,6 +807,7 @@ run_service_once() {
     start_ray_cluster
     start_lgtm
     start_twinkle_server
+    start_dashserving_adapter
     wait_runtime
 }
 

--- a/cookbook/client/server/megatron/server_config.yaml
+++ b/cookbook/client/server/megatron/server_config.yaml
@@ -7,7 +7,7 @@ proxy_location: EveryNode
 # HTTP listener settings
 http_options:
   host: 0.0.0.0        # Listen on all network interfaces
-  port: 9000            # Port number for the server
+  port: 8000            # Private runtime port; ASI Adapter owns public port 9000
 
 # Telemetry: push traces/metrics/logs to LGTM's OTel Collector via OTLP
 telemetry:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
 [project.scripts]
 twinkle-server = "twinkle.server.cli:main"
 twinkle-auto = "twinkle_client.auto:main"
+twinkle-dashserving-adapter = "twinkle.server.dashserving.__main__:main"
 
 [project.optional-dependencies]
 megatron = ["megatron-core>=0.12.0", "transformer-engine[pytorch]", "mcore_bridge"]
@@ -39,6 +40,7 @@ client = [
   "tinker==0.16.1",
 ]
 server = [
+  "httpx>=0.25.0",
   "redis>=5.0",
   "psutil>=5.9.0",
   "pynvml>=11.0.0",
@@ -46,6 +48,7 @@ server = [
   "opentelemetry-sdk",
   "opentelemetry-exporter-otlp",
   "opentelemetry-instrumentation-logging",
+  "uvicorn>=0.24.0",
 ]
 test = [
   "hypothesis>=6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 twinkle-server = "twinkle.server.cli:main"
 twinkle-auto = "twinkle_client.auto:main"
 twinkle-dashserving-adapter = "twinkle.server.dashserving.__main__:main"
+twinkle-service-mesh-gateway = "twinkle.server.mesh_gateway.__main__:main"
 
 [project.optional-dependencies]
 megatron = ["megatron-core>=0.12.0", "transformer-engine[pytorch]", "mcore_bridge"]

--- a/src/twinkle/server/common/tunnel.py
+++ b/src/twinkle/server/common/tunnel.py
@@ -1,0 +1,31 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""HTTP request and response payloads carried between service boundaries."""
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, field_validator
+from typing import Any
+
+
+class TunnelRequest(BaseModel):
+    """One Twinkle or Tinker HTTP request addressed to the local runtime."""
+
+    method: str = Field(min_length=1)
+    path: str
+    query: dict[str, str] = Field(default_factory=dict)
+    headers: dict[str, str] = Field(default_factory=dict)
+    body: Any = None
+
+    @field_validator('path')
+    @classmethod
+    def validate_path(cls, path: str) -> str:
+        if not path.startswith('/api/v1/'):
+            raise ValueError('path must start with /api/v1/')
+        return path
+
+
+class TunnelResponse(BaseModel):
+    """The original runtime HTTP response, serializable inside DashScope output."""
+
+    status_code: int = Field(ge=100, le=599)
+    headers: dict[str, str] = Field(default_factory=dict)
+    body: Any = None

--- a/src/twinkle/server/dashserving/__init__.py
+++ b/src/twinkle/server/dashserving/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""DashServing Native HTTP adapter for the Twinkle server."""
+
+from .app import create_dashserving_app
+
+__all__ = ['create_dashserving_app']

--- a/src/twinkle/server/dashserving/__main__.py
+++ b/src/twinkle/server/dashserving/__main__.py
@@ -11,7 +11,7 @@ def main() -> None:
     from .app import create_dashserving_app
 
     upstream_url = os.getenv('TWINKLE_INTERNAL_URL', 'http://127.0.0.1:8000')
-    port = int(os.getenv('PORT', '8091'))
+    port = int(os.getenv('PORT', '9000'))
     timeout_seconds = float(os.getenv('TWINKLE_DS_TIMEOUT_SECONDS', '600'))
     app = create_dashserving_app(
         upstream_url=upstream_url,

--- a/src/twinkle/server/dashserving/__main__.py
+++ b/src/twinkle/server/dashserving/__main__.py
@@ -1,0 +1,24 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""Standalone launcher for the Twinkle DashServing adapter."""
+from __future__ import annotations
+
+import os
+
+
+def main() -> None:
+    import uvicorn
+
+    from .app import create_dashserving_app
+
+    upstream_url = os.getenv('TWINKLE_INTERNAL_URL', 'http://127.0.0.1:8000')
+    port = int(os.getenv('PORT', '8091'))
+    timeout_seconds = float(os.getenv('TWINKLE_DS_TIMEOUT_SECONDS', '600'))
+    app = create_dashserving_app(
+        upstream_url=upstream_url,
+        timeout_seconds=timeout_seconds,
+    )
+    uvicorn.run(app, host='0.0.0.0', port=port)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/twinkle/server/dashserving/app.py
+++ b/src/twinkle/server/dashserving/app.py
@@ -1,0 +1,162 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""FastAPI application implementing DashServing Native HTTP for Twinkle."""
+from __future__ import annotations
+
+import httpx
+import json
+import uuid
+from contextlib import asynccontextmanager
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from pydantic import ValidationError
+from typing import AsyncIterator
+
+from twinkle.utils.logger import get_logger
+from .proxy import RuntimeProxy
+from .schemas import TunnelRequest
+
+logger = get_logger()
+
+_DS_REQUEST_ID = 'X-DashServing-Request-Id'
+_DS_ATTRIBUTES = 'X-DashServing-Attributes'
+_DS_USAGE = 'X-DashServing-Usage'
+_DS_STATUS_CODE = 'X-DashServing-Status-Code'
+_DS_STATUS_NAME = 'X-DashServing-Status-Name'
+_DS_STATUS_MESSAGE = 'X-DashServing-Status-Message'
+
+
+def create_dashserving_app(
+    *,
+    upstream_url: str = 'http://127.0.0.1:8000',
+    timeout_seconds: float = 600.0,
+    proxy: RuntimeProxy | None = None,
+) -> FastAPI:
+    """Create the standalone DashServing adapter application.
+
+    A caller-provided proxy is useful for tests and is owned by the caller.
+    Otherwise this application creates and closes its own proxy client.
+    """
+    owns_proxy = proxy is None
+    tunnel_proxy = proxy or RuntimeProxy(
+        upstream_url=upstream_url,
+        timeout_seconds=timeout_seconds,
+    )
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+        yield
+        if owns_proxy:
+            await tunnel_proxy.close()
+
+    app = FastAPI(
+        title='Twinkle DashServing Adapter',
+        description='DashServing Native HTTP adapter for the Twinkle server',
+        lifespan=lifespan,
+    )
+
+    @app.get('/health')
+    async def health() -> JSONResponse:
+        if await tunnel_proxy.health():
+            return JSONResponse({
+                'status': 'healthy',
+                'runtime_upstream': 'healthy',
+            })
+        return JSONResponse(
+            {
+                'status': 'unhealthy',
+                'runtime_upstream': 'unhealthy',
+            },
+            status_code=503,
+        )
+
+    @app.post('/api')
+    async def native_http(request: Request) -> JSONResponse:
+        request_id = request.headers.get(_DS_REQUEST_ID) or str(uuid.uuid4())
+
+        try:
+            body = await request.json()
+            tunnel_request = TunnelRequest.model_validate(body)
+        except (json.JSONDecodeError, ValidationError, ValueError):
+            return _error_response(
+                request_id=request_id,
+                status_code=400,
+                status_name='InvalidRequest',
+                message='Invalid tunnel request body.',
+            )
+
+        try:
+            tunnel_response = await tunnel_proxy.forward(tunnel_request)
+        except httpx.TimeoutException:
+            return _error_response(
+                request_id=request_id,
+                status_code=504,
+                status_name='UpstreamTimeout',
+                message='Runtime upstream timed out.',
+            )
+        except httpx.HTTPError:
+            return _error_response(
+                request_id=request_id,
+                status_code=502,
+                status_name='UpstreamError',
+                message='Runtime upstream request failed.',
+            )
+        except Exception:
+            logger.exception('Unhandled DashServing adapter error request_id=%s', request_id)
+            return _error_response(
+                request_id=request_id,
+                status_code=500,
+                status_name='InternalError',
+                message='DashServing adapter failed.',
+            )
+
+        return JSONResponse(
+            tunnel_response.model_dump(mode='json'),
+            status_code=200,
+            headers=_dashserving_headers(
+                request_id=request_id,
+                status_code=200,
+                status_name='Success',
+                message='Success.',
+            ),
+        )
+
+    return app
+
+
+def _error_response(
+    *,
+    request_id: str,
+    status_code: int,
+    status_name: str,
+    message: str,
+) -> JSONResponse:
+    return JSONResponse(
+        {'error': {
+            'code': status_name,
+            'message': message,
+        }},
+        status_code=status_code,
+        headers=_dashserving_headers(
+            request_id=request_id,
+            status_code=status_code,
+            status_name=status_name,
+            message=message,
+        ),
+    )
+
+
+def _dashserving_headers(
+    *,
+    request_id: str,
+    status_code: int,
+    status_name: str,
+    message: str,
+) -> dict[str, str]:
+    return {
+        _DS_REQUEST_ID: request_id,
+        _DS_ATTRIBUTES: '{}',
+        _DS_USAGE: '{}',
+        _DS_STATUS_CODE: str(status_code),
+        _DS_STATUS_NAME: status_name,
+        _DS_STATUS_MESSAGE: message,
+    }

--- a/src/twinkle/server/dashserving/app.py
+++ b/src/twinkle/server/dashserving/app.py
@@ -13,7 +13,7 @@ from typing import AsyncIterator
 
 from twinkle.utils.logger import get_logger
 from .proxy import RuntimeProxy
-from .schemas import TunnelRequest
+from twinkle.server.common.tunnel import TunnelRequest
 
 logger = get_logger()
 

--- a/src/twinkle/server/dashserving/app.py
+++ b/src/twinkle/server/dashserving/app.py
@@ -11,9 +11,9 @@ from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 from typing import AsyncIterator
 
+from twinkle.server.common.tunnel import TunnelRequest
 from twinkle.utils.logger import get_logger
 from .proxy import RuntimeProxy
-from twinkle.server.common.tunnel import TunnelRequest
 
 logger = get_logger()
 

--- a/src/twinkle/server/dashserving/proxy.py
+++ b/src/twinkle/server/dashserving/proxy.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import httpx
 from typing import Any
 
-from .schemas import TunnelRequest, TunnelResponse
+from twinkle.server.common.tunnel import TunnelRequest, TunnelResponse
 
 _HOP_BY_HOP_HEADERS = {
     'connection',

--- a/src/twinkle/server/dashserving/proxy.py
+++ b/src/twinkle/server/dashserving/proxy.py
@@ -1,0 +1,91 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""Fixed-upstream proxy used by the DashServing adapter."""
+from __future__ import annotations
+
+import httpx
+from typing import Any
+
+from .schemas import TunnelRequest, TunnelResponse
+
+_HOP_BY_HOP_HEADERS = {
+    'connection',
+    'content-length',
+    'host',
+    'transfer-encoding',
+}
+
+
+class RuntimeProxy:
+    """Proxy tunnel requests to one configured Twinkle server.
+
+    The target origin is constructor configuration, never request data. This is
+    the security boundary that prevents the adapter from becoming an open proxy.
+    """
+
+    def __init__(
+        self,
+        upstream_url: str,
+        *,
+        timeout_seconds: float = 600.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._upstream_url = upstream_url.rstrip('/')
+        self._owns_client = client is None
+        self._client = client or httpx.AsyncClient(
+            timeout=httpx.Timeout(timeout_seconds),
+            trust_env=False,
+        )
+
+    async def close(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def health(self) -> bool:
+        try:
+            response = await self._client.get(
+                f'{self._upstream_url}/api/v1/twinkle/healthz',
+                timeout=5.0,
+            )
+            return response.status_code == 200
+        except httpx.HTTPError:
+            return False
+
+    async def forward(self, tunnel_request: TunnelRequest) -> TunnelResponse:
+        headers = self._build_headers(tunnel_request)
+        request_kwargs: dict[str, Any] = {
+            'method': tunnel_request.method,
+            'url': f'{self._upstream_url}{tunnel_request.path}',
+            'params': tunnel_request.query,
+            'headers': headers,
+        }
+        if tunnel_request.body is not None:
+            request_kwargs['json'] = tunnel_request.body
+
+        response = await self._client.request(**request_kwargs)
+        if not response.content:
+            response_body = None
+        else:
+            try:
+                response_body = response.json()
+            except ValueError:
+                response_body = response.text
+
+        response_headers = {
+            'content-type': response.headers.get('content-type', 'application/json'),
+        }
+        replica_id = response.headers.get('x-twinkle-replica-id')
+        if replica_id:
+            response_headers['x-twinkle-replica-id'] = replica_id
+
+        return TunnelResponse(
+            status_code=response.status_code,
+            headers=response_headers,
+            body=response_body,
+        )
+
+    @staticmethod
+    def _build_headers(tunnel_request: TunnelRequest) -> dict[str, str]:
+        return {
+            name: value
+            for name, value in tunnel_request.headers.items() if name.lower() not in _HOP_BY_HOP_HEADERS
+        }

--- a/src/twinkle/server/dashserving/schemas.py
+++ b/src/twinkle/server/dashserving/schemas.py
@@ -1,29 +1,6 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
-"""Minimal private HTTP tunnel models used by ModelScope and DashServing."""
-from __future__ import annotations
+"""Compatibility exports for the shared service-boundary payloads."""
 
-from pydantic import BaseModel, Field, field_validator
-from typing import Any
+from twinkle.server.common.tunnel import TunnelRequest, TunnelResponse
 
-
-class TunnelRequest(BaseModel):
-    """HTTP request to forward to the internal `/api/v1/` server."""
-
-    method: str = Field(min_length=1)
-    path: str
-    query: dict[str, str] = Field(default_factory=dict)
-    headers: dict[str, str] = Field(default_factory=dict)
-    body: Any = None
-
-    @field_validator('path')
-    @classmethod
-    def validate_path(cls, path: str) -> str:
-        if not path.startswith('/api/v1/'):
-            raise ValueError('path must start with /api/v1/')
-        return path
-
-
-class TunnelResponse(BaseModel):
-    status_code: int = Field(ge=100, le=599)
-    headers: dict[str, str] = Field(default_factory=dict)
-    body: Any = None
+__all__ = ['TunnelRequest', 'TunnelResponse']

--- a/src/twinkle/server/dashserving/schemas.py
+++ b/src/twinkle/server/dashserving/schemas.py
@@ -1,6 +1,0 @@
-# Copyright (c) ModelScope Contributors. All rights reserved.
-"""Compatibility exports for the shared service-boundary payloads."""
-
-from twinkle.server.common.tunnel import TunnelRequest, TunnelResponse
-
-__all__ = ['TunnelRequest', 'TunnelResponse']

--- a/src/twinkle/server/dashserving/schemas.py
+++ b/src/twinkle/server/dashserving/schemas.py
@@ -1,0 +1,29 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""Minimal private HTTP tunnel models used by ModelScope and DashServing."""
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, field_validator
+from typing import Any
+
+
+class TunnelRequest(BaseModel):
+    """HTTP request to forward to the internal `/api/v1/` server."""
+
+    method: str = Field(min_length=1)
+    path: str
+    query: dict[str, str] = Field(default_factory=dict)
+    headers: dict[str, str] = Field(default_factory=dict)
+    body: Any = None
+
+    @field_validator('path')
+    @classmethod
+    def validate_path(cls, path: str) -> str:
+        if not path.startswith('/api/v1/'):
+            raise ValueError('path must start with /api/v1/')
+        return path
+
+
+class TunnelResponse(BaseModel):
+    status_code: int = Field(ge=100, le=599)
+    headers: dict[str, str] = Field(default_factory=dict)
+    body: Any = None

--- a/src/twinkle/server/mesh_gateway/__init__.py
+++ b/src/twinkle/server/mesh_gateway/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""Public Twinkle gateway that reaches the training service through Service Mesh."""
+
+from .app import create_mesh_gateway_app
+
+__all__ = ['create_mesh_gateway_app']

--- a/src/twinkle/server/mesh_gateway/__main__.py
+++ b/src/twinkle/server/mesh_gateway/__main__.py
@@ -1,0 +1,23 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""Standalone launcher for the CPU-side Service Mesh gateway."""
+from __future__ import annotations
+
+import os
+
+
+def main() -> None:
+    import uvicorn
+
+    from .app import create_mesh_gateway_app
+
+    gpu_service_id = os.environ['TWINKLE_GPU_SERVICE_ID']
+    app = create_mesh_gateway_app(
+        gpu_service_id=gpu_service_id,
+        mesh_url=os.getenv('TWINKLE_SERVICE_MESH_URL', 'http://127.0.0.1:8880/api/v2/inference'),
+        timeout_seconds=float(os.getenv('TWINKLE_SERVICE_MESH_TIMEOUT_SECONDS', '620')),
+    )
+    uvicorn.run(app, host='0.0.0.0', port=int(os.getenv('PORT', '9000')))
+
+
+if __name__ == '__main__':
+    main()

--- a/src/twinkle/server/mesh_gateway/app.py
+++ b/src/twinkle/server/mesh_gateway/app.py
@@ -1,0 +1,82 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""Public Twinkle HTTP gateway backed by a configured Service Mesh target."""
+from __future__ import annotations
+
+import httpx
+import json
+import uuid
+from contextlib import asynccontextmanager
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from typing import AsyncIterator
+
+from twinkle.server.common.tunnel import TunnelRequest
+from .proxy import ServiceMeshError, ServiceMeshProxy
+
+
+def create_mesh_gateway_app(
+    *,
+    gpu_service_id: str,
+    mesh_url: str = 'http://127.0.0.1:8880/api/v2/inference',
+    timeout_seconds: float = 620.0,
+    proxy: ServiceMeshProxy | None = None,
+) -> FastAPI:
+    """Create the CPU-side public gateway for one GPU training service."""
+    owns_proxy = proxy is None
+    mesh_proxy = proxy or ServiceMeshProxy(
+        gpu_service_id,
+        mesh_url=mesh_url,
+        timeout_seconds=timeout_seconds,
+    )
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+        yield
+        if owns_proxy:
+            await mesh_proxy.close()
+
+    app = FastAPI(
+        title='Twinkle Service Mesh Gateway',
+        description='Public Twinkle and Tinker gateway for one GPU service',
+        lifespan=lifespan,
+    )
+
+    @app.get('/health')
+    async def health() -> JSONResponse:
+        return JSONResponse({'status': 'healthy'})
+
+    @app.api_route('/api/v1/{path:path}', methods=['GET', 'POST', 'DELETE'])
+    async def forward(path: str, request: Request) -> JSONResponse:
+        request_id = request.headers.get('x-request-id') or str(uuid.uuid4())
+        try:
+            body = await _request_body(request)
+            tunnel_request = TunnelRequest(
+                method=request.method,
+                path=f'/api/v1/{path}',
+                query=dict(request.query_params),
+                headers=dict(request.headers),
+                body=body,
+            )
+        except (json.JSONDecodeError, ValueError):
+            return JSONResponse({'detail': 'Request body must be JSON.'}, status_code=400)
+
+        try:
+            tunnel_response = await mesh_proxy.forward(request_id, tunnel_request)
+        except httpx.TimeoutException:
+            return JSONResponse({'detail': 'GPU service timed out.'}, status_code=504)
+        except (httpx.HTTPError, ServiceMeshError):
+            return JSONResponse({'detail': 'GPU service is unavailable.'}, status_code=502)
+
+        return JSONResponse(
+            tunnel_response.body,
+            status_code=tunnel_response.status_code,
+            headers=tunnel_response.headers,
+        )
+
+    return app
+
+
+async def _request_body(request: Request):
+    if not await request.body():
+        return None
+    return await request.json()

--- a/src/twinkle/server/mesh_gateway/proxy.py
+++ b/src/twinkle/server/mesh_gateway/proxy.py
@@ -1,0 +1,60 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""Client for the platform-provided Service Mesh endpoint."""
+from __future__ import annotations
+
+import httpx
+
+from twinkle.server.common.tunnel import TunnelRequest, TunnelResponse
+
+
+class ServiceMeshError(Exception):
+    """The mesh returned a response that cannot be restored for the client."""
+
+
+class ServiceMeshProxy:
+    """Send Twinkle requests to one configured GPU service through Service Mesh."""
+
+    def __init__(
+        self,
+        service_id: str,
+        *,
+        mesh_url: str = 'http://127.0.0.1:8880/api/v2/inference',
+        timeout_seconds: float = 620.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._service_id = service_id
+        self._mesh_url = mesh_url
+        self._owns_client = client is None
+        self._client = client or httpx.AsyncClient(
+            timeout=httpx.Timeout(timeout_seconds),
+            trust_env=False,
+        )
+
+    async def close(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def forward(self, request_id: str, tunnel_request: TunnelRequest) -> TunnelResponse:
+        response = await self._client.post(
+            self._mesh_url,
+            json={
+                'header': {
+                    'request_id': request_id,
+                    'service_id': self._service_id,
+                },
+                'payload': {
+                    'input': tunnel_request.model_dump(mode='json'),
+                    'parameters': {},
+                },
+            },
+        )
+        response.raise_for_status()
+
+        try:
+            payload = response.json()
+            header = payload['header']
+            if header.get('status_code') != 200:
+                raise ServiceMeshError(header.get('status_message', 'Service Mesh request failed.'))
+            return TunnelResponse.model_validate(payload['payload']['output'])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ServiceMeshError('Invalid Service Mesh response.') from exc

--- a/tests/dashserving/test_mock_e2e.py
+++ b/tests/dashserving/test_mock_e2e.py
@@ -18,7 +18,7 @@ from fastapi.responses import JSONResponse, Response
 
 from twinkle.server.dashserving import create_dashserving_app
 from twinkle.server.dashserving.proxy import RuntimeProxy
-from twinkle.server.dashserving.schemas import TunnelResponse
+from twinkle.server.common.tunnel import TunnelResponse
 
 
 def _build_runtime_mock() -> FastAPI:

--- a/tests/dashserving/test_mock_e2e.py
+++ b/tests/dashserving/test_mock_e2e.py
@@ -1,0 +1,300 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""Local HTTP tunnel mock using the production DashServing adapter code.
+
+This HTTP-level test lives outside ``tests/server`` because it does not
+need that suite's session-scoped Ray cluster.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+import httpx
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, Response
+
+from twinkle.server.dashserving import create_dashserving_app
+from twinkle.server.dashserving.proxy import RuntimeProxy
+from twinkle.server.dashserving.schemas import TunnelResponse
+
+
+def _build_runtime_mock() -> FastAPI:
+    """Represent the existing server exposing Twinkle and Tinker APIs."""
+    app = FastAPI()
+
+    @app.api_route('/api/v1/{path:path}', methods=['GET', 'POST', 'DELETE'])
+    async def twinkle_endpoint(path: str, request: Request) -> JSONResponse:
+        if path == 'twinkle/healthz':
+            return JSONResponse({'status': 'ok'})
+        if path.endswith('/expired'):
+            return JSONResponse({'detail': 'checkpoint expired'}, status_code=410)
+
+        body = await request.json() if request.method == 'POST' else None
+        observed_headers = {
+            name: request.headers.get(name)
+            for name in (
+                'x-request-id',
+                'x-ray-serve-request-id',
+                'serve_multiplexed_model_id',
+                'serve-multiplexed-model-id',
+                'authorization',
+                'twinkle-authorization',
+                'x-twinkle-session-id',
+            )
+        }
+        return JSONResponse({
+            'method': request.method,
+            'path': request.url.path,
+            'query': dict(request.query_params),
+            'headers': observed_headers,
+            'body': body,
+        })
+
+    return app
+
+
+def _build_dashserving_mock(adapter_client: httpx.AsyncClient) -> FastAPI:
+    """Represent DS forwarding a Native HTTP request to runtime `/api`."""
+    app = FastAPI()
+
+    @app.post('/invoke')
+    async def invoke(request: Request) -> Response:
+        ds_request_id = request.headers.get('x-mock-ds-request-id') or str(uuid.uuid4())
+        adapter_response = await adapter_client.post(
+            '/api',
+            content=await request.body(),
+            headers={
+                'Content-Type': 'application/json',
+                'X-DashServing-Request-Id': ds_request_id,
+            },
+        )
+        response_headers = {
+            name: value
+            for name, value in adapter_response.headers.items()
+            if name.lower().startswith('x-dashserving-')
+        }
+        return Response(
+            content=adapter_response.content,
+            status_code=adapter_response.status_code,
+            headers=response_headers,
+            media_type='application/json',
+        )
+
+    return app
+
+
+def _build_modelscope_mock(ds_client: httpx.AsyncClient) -> FastAPI:
+    """Represent the ModelScope public route and tunnel codec."""
+    app = FastAPI()
+
+    @app.api_route('/tinker/api/v1/{path:path}', methods=['GET', 'POST', 'DELETE'])
+    @app.api_route('/twinkle/api/v1/{path:path}', methods=['GET', 'POST', 'DELETE'])
+    async def runtime_route(path: str, request: Request) -> Response:
+        authorization = request.headers.get('authorization')
+        twinkle_request_id = request.headers.get('x-request-id')
+        if not authorization:
+            return JSONResponse({'detail': 'missing authorization'}, status_code=401)
+        if not twinkle_request_id:
+            return JSONResponse({'detail': 'missing x-request-id'}, status_code=400)
+
+        forwarded_headers = {
+            'authorization',
+            'serve-multiplexed-model-id',
+            'serve_multiplexed_model_id',
+            'twinkle-authorization',
+            'x-ray-serve-request-id',
+            'x-request-id',
+            'x-twinkle-session-id',
+        }
+        tunnel_request = {
+            'method': request.method,
+            # The mounted route already consumed the public prefix.
+            'path': f'/api/v1/{path}',
+            'query': dict(request.query_params),
+            'headers': {
+                name: value
+                for name, value in request.headers.items()
+                if name.lower() in forwarded_headers
+            },
+            'body': await request.json() if request.method == 'POST' else None,
+        }
+        ds_request_id = f'ds-{uuid.uuid4()}'
+        ds_response = await ds_client.post(
+            '/invoke',
+            json=tunnel_request,
+            headers={'X-Mock-DS-Request-Id': ds_request_id},
+        )
+        if ds_response.status_code == 504:
+            return JSONResponse({'detail': 'DashServing timeout'}, status_code=504)
+        if ds_response.status_code != 200:
+            return JSONResponse({'detail': 'DashServing invocation failed'}, status_code=502)
+
+        required_ds_headers = {
+            'x-dashserving-request-id',
+            'x-dashserving-attributes',
+            'x-dashserving-usage',
+            'x-dashserving-status-code',
+            'x-dashserving-status-name',
+            'x-dashserving-status-message',
+        }
+        if not required_ds_headers.issubset(ds_response.headers):
+            return JSONResponse({'detail': 'DashServing response error'}, status_code=502)
+        if ds_response.headers['x-dashserving-request-id'] != ds_request_id:
+            return JSONResponse({'detail': 'DashServing request ID mismatch'}, status_code=502)
+        if ds_response.headers['x-dashserving-status-code'] != '200':
+            return JSONResponse({'detail': 'DashServing status error'}, status_code=502)
+        attributes = json.loads(ds_response.headers['x-dashserving-attributes'])
+        if attributes != {}:
+            return JSONResponse({'detail': 'Unexpected DashServing attributes'}, status_code=502)
+
+        tunnel_response = TunnelResponse.model_validate(ds_response.json())
+        response_headers = {}
+        content_type = tunnel_response.headers.get('content-type')
+        if content_type:
+            response_headers['Content-Type'] = content_type
+        return JSONResponse(
+            tunnel_response.body,
+            status_code=tunnel_response.status_code,
+            headers=response_headers,
+        )
+
+    return app
+
+
+@asynccontextmanager
+async def _mock_chain() -> AsyncIterator[tuple[httpx.AsyncClient, httpx.AsyncClient]]:
+    """Build Client -> ModelScope -> DS -> real Adapter -> Twinkle mock."""
+    runtime_app = _build_runtime_mock()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=runtime_app),
+        base_url='http://runtime-internal',
+    ) as runtime_client:
+        proxy = RuntimeProxy('http://runtime-internal', client=runtime_client)
+        adapter_app = create_dashserving_app(proxy=proxy)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=adapter_app),
+            base_url='http://adapter',
+        ) as adapter_client:
+            ds_app = _build_dashserving_mock(adapter_client)
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=ds_app),
+                base_url='http://dashserving',
+            ) as ds_client:
+                modelscope_app = _build_modelscope_mock(ds_client)
+                async with httpx.AsyncClient(
+                    transport=httpx.ASGITransport(app=modelscope_app),
+                    base_url='http://modelscope',
+                ) as user_client:
+                    yield user_client, adapter_client
+
+
+def _client_headers(*, session_id: str | None = None) -> dict[str, str]:
+    headers = {
+        'Authorization': 'Bearer user-token',
+        'Twinkle-Authorization': 'Bearer user-token',
+        'x-request-id': 'client-sticky-01',
+        'X-Ray-Serve-Request-Id': 'client-sticky-01',
+        'serve_multiplexed_model_id': 'client-sticky-01',
+        'Serve-Multiplexed-Model-Id': 'client-sticky-01',
+    }
+    if session_id:
+        headers['X-Twinkle-Session-Id'] = session_id
+    return headers
+
+
+@pytest.mark.asyncio
+async def test_post_crosses_the_complete_mock_chain() -> None:
+    async with _mock_chain() as (client, _adapter):
+        response = await client.post(
+            '/twinkle/api/v1/model/Qwen/Qwen3.6-27B/twinkle/forward_backward?timeout=20',
+            headers=_client_headers(session_id='session-123'),
+            json={'inputs': [], 'adapter_name': 'default'},
+        )
+
+    assert response.status_code == 200
+    assert 'x-dashserving-request-id' not in response.headers
+    observed = response.json()
+    assert observed['method'] == 'POST'
+    assert observed['path'] == '/api/v1/model/Qwen/Qwen3.6-27B/twinkle/forward_backward'
+    assert observed['query'] == {'timeout': '20'}
+    assert observed['body'] == {'inputs': [], 'adapter_name': 'default'}
+    assert observed['headers'] == {
+        'x-request-id': 'client-sticky-01',
+        'x-ray-serve-request-id': 'client-sticky-01',
+        'serve_multiplexed_model_id': 'client-sticky-01',
+        'serve-multiplexed-model-id': 'client-sticky-01',
+        'authorization': 'Bearer user-token',
+        'twinkle-authorization': 'Bearer user-token',
+        'x-twinkle-session-id': 'session-123',
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_query_and_inner_status_survive_the_chain() -> None:
+    async with _mock_chain() as (client, _adapter):
+        get_response = await client.get(
+            '/twinkle/api/v1/twinkle/training_runs?limit=20',
+            headers=_client_headers(),
+        )
+        gone_response = await client.delete(
+            '/twinkle/api/v1/twinkle/checkpoints/expired',
+            headers=_client_headers(),
+        )
+
+    assert get_response.status_code == 200
+    assert get_response.json()['method'] == 'GET'
+    assert get_response.json()['query'] == {'limit': '20'}
+    assert get_response.json()['body'] is None
+    assert gone_response.status_code == 410
+    assert gone_response.json() == {'detail': 'checkpoint expired'}
+
+
+@pytest.mark.asyncio
+async def test_tinker_request_crosses_the_same_adapter() -> None:
+    async with _mock_chain() as (client, _adapter):
+        response = await client.post(
+            '/tinker/api/v1/create_model',
+            headers=_client_headers(session_id='session-123'),
+            json={'base_model': 'Qwen/Qwen3.6-27B'},
+        )
+
+    assert response.status_code == 200
+    observed = response.json()
+    assert observed['path'] == '/api/v1/create_model'
+    assert observed['body'] == {'base_model': 'Qwen/Qwen3.6-27B'}
+    assert observed['headers']['authorization'] == 'Bearer user-token'
+    assert observed['headers']['x-request-id'] == 'client-sticky-01'
+
+
+@pytest.mark.asyncio
+async def test_adapter_native_http_contract() -> None:
+    async with _mock_chain() as (_client, adapter):
+        tunnel_request = {
+            'method': 'POST',
+            'path': '/api/v1/create_model',
+            'headers': _client_headers(),
+            'body': {'base_model': 'Qwen/Qwen3.6-27B'},
+        }
+        response = await adapter.post('/api', json=tunnel_request)
+
+    assert response.status_code == 200
+    assert response.headers['x-dashserving-request-id']
+    assert response.headers['x-dashserving-status-code'] == '200'
+    assert response.headers['x-dashserving-status-name'] == 'Success'
+    assert response.headers['x-dashserving-attributes'] == '{}'
+    assert response.headers['x-dashserving-usage'] == '{}'
+
+
+@pytest.mark.asyncio
+async def test_adapter_health_checks_runtime_upstream() -> None:
+    async with _mock_chain() as (_client, adapter):
+        response = await adapter.get('/health')
+
+    assert response.status_code == 200
+    assert response.json() == {
+        'status': 'healthy',
+        'runtime_upstream': 'healthy',
+    }

--- a/tests/dashserving/test_service_mesh_e2e.py
+++ b/tests/dashserving/test_service_mesh_e2e.py
@@ -1,0 +1,179 @@
+# Copyright (c) ModelScope Contributors. All rights reserved.
+"""CPU Gateway -> Service Mesh -> GPU Adapter integration mock."""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+import httpx
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from twinkle.server.dashserving import create_dashserving_app
+from twinkle.server.dashserving.proxy import RuntimeProxy
+from twinkle.server.mesh_gateway import create_mesh_gateway_app
+from twinkle.server.mesh_gateway.proxy import ServiceMeshProxy
+
+_GPU_SERVICE_ID = 'gpu-training-service'
+
+
+def _build_runtime_mock() -> FastAPI:
+    app = FastAPI()
+
+    @app.api_route('/api/v1/{path:path}', methods=['GET', 'POST', 'DELETE'])
+    async def endpoint(path: str, request: Request) -> JSONResponse:
+        if path == 'twinkle/healthz':
+            return JSONResponse({'status': 'ok'})
+        if path.endswith('/expired'):
+            return JSONResponse({'detail': 'checkpoint expired'}, status_code=410)
+
+        return JSONResponse({
+            'method': request.method,
+            'path': request.url.path,
+            'query': dict(request.query_params),
+            'headers': {
+                'authorization': request.headers.get('authorization'),
+                'x-request-id': request.headers.get('x-request-id'),
+            },
+            'body': await request.json() if request.method == 'POST' else None,
+        })
+
+    return app
+
+
+def _build_service_mesh_mock(adapter_client: httpx.AsyncClient) -> FastAPI:
+    """Mock the platform routing by service ID and Native HTTP conversion."""
+    app = FastAPI()
+    app.state.requests = []
+
+    @app.post('/api/v2/inference')
+    async def inference(request: Request) -> JSONResponse:
+        mesh_request = await request.json()
+        app.state.requests.append(mesh_request)
+        request_id = mesh_request['header']['request_id']
+        if mesh_request['header'].get('service_id') != _GPU_SERVICE_ID:
+            return JSONResponse({
+                'header': {
+                    'request_id': request_id,
+                    'status_code': 404,
+                    'status_name': 'ServiceNotFound',
+                    'status_message': 'Unknown service ID.',
+                },
+                'payload': {'output': {}},
+            })
+
+        adapter_response = await adapter_client.post(
+            '/api',
+            json=mesh_request['payload']['input'],
+            headers={'X-DashServing-Request-Id': request_id},
+        )
+        status_code = int(adapter_response.headers['x-dashserving-status-code'])
+        return JSONResponse({
+            'header': {
+                'request_id': request_id,
+                'status_code': status_code,
+                'status_name': adapter_response.headers['x-dashserving-status-name'],
+                'status_message': adapter_response.headers['x-dashserving-status-message'],
+            },
+            'payload': {'output': adapter_response.json()},
+        })
+
+    return app
+
+
+@asynccontextmanager
+async def _mock_chain() -> AsyncIterator[tuple[httpx.AsyncClient, FastAPI]]:
+    """Build Client -> CPU Gateway -> Mesh Mock -> GPU Adapter -> Twinkle Mock."""
+    runtime_app = _build_runtime_mock()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=runtime_app),
+        base_url='http://runtime',
+    ) as runtime_client:
+        adapter_app = create_dashserving_app(
+            proxy=RuntimeProxy('http://runtime', client=runtime_client))
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=adapter_app),
+            base_url='http://gpu-adapter',
+        ) as adapter_client:
+            mesh_app = _build_service_mesh_mock(adapter_client)
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=mesh_app),
+                base_url='http://service-mesh',
+            ) as mesh_client:
+                gateway_app = create_mesh_gateway_app(
+                    gpu_service_id=_GPU_SERVICE_ID,
+                    proxy=ServiceMeshProxy(
+                        _GPU_SERVICE_ID,
+                        mesh_url='http://service-mesh/api/v2/inference',
+                        client=mesh_client,
+                    ),
+                )
+                async with httpx.AsyncClient(
+                    transport=httpx.ASGITransport(app=gateway_app),
+                    base_url='http://cpu-gateway',
+                ) as user_client:
+                    yield user_client, mesh_app
+
+
+def _client_headers() -> dict[str, str]:
+    return {
+        'Authorization': 'Bearer user-token',
+        'X-Request-Id': 'client-request-01',
+    }
+
+
+@pytest.mark.asyncio
+async def test_twinkle_request_crosses_cpu_mesh_and_gpu() -> None:
+    async with _mock_chain() as (client, mesh_app):
+        response = await client.post(
+            '/api/v1/model/Qwen/Qwen3.6-27B/twinkle/forward_backward?timeout=20',
+            headers=_client_headers(),
+            json={'inputs': [], 'adapter_name': 'default'},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        'method': 'POST',
+        'path': '/api/v1/model/Qwen/Qwen3.6-27B/twinkle/forward_backward',
+        'query': {'timeout': '20'},
+        'headers': {
+            'authorization': 'Bearer user-token',
+            'x-request-id': 'client-request-01',
+        },
+        'body': {'inputs': [], 'adapter_name': 'default'},
+    }
+    mesh_request = mesh_app.state.requests[0]
+    assert mesh_request['header'] == {
+        'request_id': 'client-request-01',
+        'service_id': _GPU_SERVICE_ID,
+    }
+    assert mesh_request['payload']['parameters'] == {}
+
+
+@pytest.mark.asyncio
+async def test_tinker_and_inner_error_status_are_restored_for_the_client() -> None:
+    async with _mock_chain() as (client, _mesh_app):
+        tinker_response = await client.post(
+            '/api/v1/create_model',
+            headers=_client_headers(),
+            json={'base_model': 'Qwen/Qwen3.6-27B'},
+        )
+        expired_response = await client.delete(
+            '/api/v1/twinkle/checkpoints/expired',
+            headers=_client_headers(),
+        )
+
+    assert tinker_response.status_code == 200
+    assert tinker_response.json()['path'] == '/api/v1/create_model'
+    assert expired_response.status_code == 410
+    assert expired_response.json() == {'detail': 'checkpoint expired'}
+
+
+@pytest.mark.asyncio
+async def test_cpu_gateway_health_is_local() -> None:
+    async with _mock_chain() as (client, _mesh_app):
+        response = await client.get('/health')
+
+    assert response.status_code == 200
+    assert response.json() == {'status': 'healthy'}


### PR DESCRIPTION
## Summary

- add a standalone DashServing Native HTTP adapter with POST /api and GET /health
- forward generic HTTP JSON requests to a fixed internal runtime for both Twinkle and Tinker APIs
- expose a dedicated adapter launcher and declare server-side HTTP dependencies
- add an end-to-end mock covering Client -> ModelScope -> DashServing -> Adapter -> runtime

## Validation

- conda run -n twinkle python -m pytest -vv -s tests/dashserving/test_mock_e2e.py (5 passed)
- pre-commit run for all changed files (all hooks passed)

## Draft follow-up

- validate body passthrough and the 600-second request path against a real DashServing runtime